### PR TITLE
#6186 - Version placeholder revnumber shown instead of the actual version in guides and downloadable example scripts

### DIFF
--- a/inception/inception-doc/pom.xml
+++ b/inception/inception-doc/pom.xml
@@ -73,8 +73,50 @@
     </dependency>
   </dependencies>
   <build>
+    <!--
+      The example scripts (Docker Compose, Kubernetes) are included into the
+      documentation *and* shipped as downloadable files. They therefore cannot
+      use Asciidoc attributes like {revnumber} to refer to the current version:
+      those are substituted when a script is included into a page, but not in
+      the copies that asciidoctor passes through verbatim into the generated
+      documentation - which is what users end up downloading.
+
+      Instead, the scripts use @project.version@, which is replaced here, so
+      that both the included listings and the downloadable files show the real
+      version.
+
+      The delimiter must be restricted to @...@: the scripts are full of
+      shell-style ${VARIABLE:-default} expressions which Maven would otherwise
+      try to interpolate.
+    -->
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>**/asciidoc/**/scripts/*.yml</include>
+        </includes>
+        <filtering>true</filtering>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>**/asciidoc/**/scripts/*.yml</exclude>
+        </excludes>
+        <filtering>false</filtering>
+      </resource>
+    </resources>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <configuration>
+            <delimiters>
+              <delimiter>@</delimiter>
+            </delimiters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/cli.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/cli.adoc
@@ -25,6 +25,7 @@ This guide provides an overview of the available commands and their usage.
 To access the {product-name} CLI, you can just add command line arguments to the Java command that starts {product-name}.
 For example:
 
+[source,shell,subs="+attributes"]
 ----
 $ java -Dinception.home="/srv/inception" -jar inception-app-webapp-{revnumber}-standalone.jar --help
 ----
@@ -32,8 +33,9 @@ $ java -Dinception.home="/srv/inception" -jar inception-app-webapp-{revnumber}-s
 If you are using Docker, you can pass the command line arguments via the `APP_ARGS` environment variable.
 For example:
 
+[source,shell,subs="+attributes"]
 ----
-$ docker run -e APP_ARGS="--help" inception/inception:{revnumber}
+$ docker run -e APP_ARGS="--help" ghcr.io/inception-project/inception:{revnumber}
 ----
 
 Note that if you usually pass other parameters startup, make sure you also pass them when you want to use the CLI - in particular the `inception.home` system property, database-related properties/variables or volume mounts.

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
@@ -132,6 +132,7 @@ You also pass additional options to the Java runtime through the `JAVA_OPTS` env
 
 By default, {product-name} runs with the UID 2000 and the GID 2000. On startup, any files belonging to {product-name} are automatically reassigned to these UID/GID, in the Docker container itself as well as in any volume potentially mounted under `/export` within the container. If you need the application to run as a different UID/GID, you can override these values when starting the container using the `APP_UID` and `APP_GID` environment variables.
 
+[source,shell,subs="+attributes"]
 ----
 $ docker run -it -e APP_UID=1234 -e APP_GID=4321 ghcr.io/inception-project/inception:{revnumber}
 ----

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
@@ -2,7 +2,6 @@
 # docker compose up [-d]
 # docker compose down
 ##
-version: '2.4'
 
 networks:
   inception-net:

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
@@ -28,7 +28,7 @@ services:
       inception-net:
 
   app:
-    image: "${INCEPTION_IMAGE:-ghcr.io/inception-project/inception}:${INCEPTION_VERSION:-{revnumber}}"
+    image: "${INCEPTION_IMAGE:-ghcr.io/inception-project/inception}:${INCEPTION_VERSION:-@project.version@}"
     ports:
       - "${INCEPTION_PORT:-8080}:8080"
     environment:

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       inception-net:
 
   app:
-    image: "${INCEPTION_IMAGE:-ghcr.io/inception-project/inception}:${INCEPTION_VERSION:-{revnumber}}"
+    image: "${INCEPTION_IMAGE:-ghcr.io/inception-project/inception}:${INCEPTION_VERSION:-@project.version@}"
     ports:
       - "${INCEPTION_PORT:-8080}:8080"
     environment:

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/kubernetes.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/kubernetes.yml
@@ -116,7 +116,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: inception
-        image: "ghcr.io/inception-project/inception-snapshots:{revnumber}"
+        image: "ghcr.io/inception-project/inception-snapshots:@project.version@"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/intro-installation.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/intro-installation.adoc
@@ -76,7 +76,7 @@ There, you can mark it as executable.
 +
 Alternatively, you can start the application from the command line:
 +
-[source,text]
+[source,text,subs="+attributes"]
 ----
 $ java -jar inception-app-standalone-{revnumber}.jar
 ----


### PR DESCRIPTION
**What's in the PR**
- Fix version placeholder substitution in Docker example scripts and code blocks
- Enable resource filtering in Maven for YAML scripts to replace @project.version@ placeholders
- Add missing Asciidoc `subs="+attributes"` to code blocks so {revnumber} substitutes in rendered guides
- Update stale Docker image name from `inception/inception:` to `ghcr.io/inception-project/inception:`

**How to test manually**
* Check documentation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
