### PR TITLE
#6185 - Docker Compose commands in the administrator guide use the obsolete docker-compose spelling

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
@@ -153,6 +153,10 @@ Using Docker Compose, you can manage multiple related containers. This section i
 Docker Compose to jointly set up a {product-name} container as well as a database container (i.e. 
 link:https://hub.docker.com/_/mariadb/[this one]).
 
+The commands in this section use the `docker compose` (Compose V2) plugin. If your host still uses
+the standalone `docker-compose` binary, use `docker-compose` instead of `docker compose` in all of
+them.
+
 The following Compose script sets these containers up.
 
 [source,text,subs="+attributes"]
@@ -166,7 +170,7 @@ the containers.
 
 [source,shell,subs="+attributes"]
 ----
-$ docker-compose -p inception up -d
+$ docker compose -p inception up -d
 ----
 
 This will start two docker containers: `inception_db_1`, and `inception_app_1`. 
@@ -190,7 +194,7 @@ start them again later, the data will still be there - try it out!
 
 [source,shell,subs="+attributes"]
 ----
-$ docker-compose -p inception down
+$ docker compose -p inception down
 ----
 
 You can list the Docker volumes on your system using
@@ -210,7 +214,7 @@ file. You can also choose to override the default location for the database data
 ----
 $ export INCEPTION_HOME=/srv/inception/app-data 
 $ export INCEPTION_DB_HOME=/srv/inception/db-data
-$ docker-compose -f docker-compose.yml -p inception up
+$ docker compose -f docker-compose.yml -p inception up
 ----
 
 If you are running Docker on Linux, the data of the volumes should end up on the file system anyway
@@ -221,7 +225,7 @@ you mount the data to folders on your host.
 
 NOTE: Mind that you cannot arbitrarily switch between volume-managed and host-stored data. Choose wisely.
 
-There is a lot more that you can do using Docker and Docker Compose. Please see the link:https://docs.docker.com/compose/[docker-compose reference] for details.
+There is a lot more that you can do using Docker and Docker Compose. Please see the link:https://docs.docker.com/compose/[Docker Compose reference] for details.
 
 === Upgrading with Docker Compose
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
@@ -1,6 +1,6 @@
 ##
-# docker-compose up [-d]
-# docker-compose down
+# docker compose up [-d]
+# docker compose down
 ##
 version: '2.4'
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
@@ -1,6 +1,6 @@
 ##
-# docker-compose up [-d]
-# docker-compose down
+# docker compose up [-d]
+# docker compose down
 ##
 
 networks:


### PR DESCRIPTION
**What's in the PR**
- Update Docker Compose documentation to use `docker compose` (Compose V2) syntax instead of deprecated `docker-compose` command
- Add clarification note about fallback to standalone `docker-compose` binary for older Docker installations
- Update example `docker-compose.yml` and `docker-compose-mysql8.yml` script headers to use `docker compose` syntax

**How to test manually**
* Check documentation, verify that the commands work

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
