### PR TITLE
#6183 - Read-only annotation page may cause exceptions after change to the layer configuration

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -405,8 +405,13 @@ public abstract class AnnotationPageBase
         var evaluator = new ConstraintsEvaluator();
         var constraints = getModelObject().getConstraints();
 
+        var maybeLayerType = aAdapter.getAnnotationType(editorCas);
+        if (maybeLayerType.isEmpty()) {
+            return;
+        }
+
         // Check each feature structure of this layer
-        var layerType = aAdapter.getAnnotationType(editorCas).get();
+        var layerType = maybeLayerType.get();
         var annotationFsType = editorCas.getAnnotationType();
         try (var fses = editorCas.select(layerType)) {
             for (var fs : fses) {
@@ -414,6 +419,11 @@ public abstract class AnnotationPageBase
                     if (!f.isRequired()) {
                         continue;
                     }
+
+                    if (!aAdapter.isFeatureDeclared(fs, f)) {
+                        continue;
+                    }
+
                     if (evaluator.isHiddenConditionalFeature(constraints, fs, f)) {
                         continue;
                     }

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -64,6 +64,7 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
@@ -582,6 +583,9 @@ public class CasMerge
     {
         // Cache the feature list instead of hammering the database
         var features = aContext.listSupportedFeatures(aAdapter.getLayer());
+        var sourceFsType = aAdapter.getAnnotationType(aSourceFs.getCAS())
+                .orElseThrow(() -> new IllegalStateException("Source CAS does not define the type ["
+                        + aAdapter.getAnnotationTypeName() + "]"));
         try (var featureUpdateCtx = aAdapter.updateFeatureValues(aDocument, aUsername,
                 aTargetFS.getCAS(), getAddr(aTargetFS))) {
             for (var feature : features) {
@@ -589,13 +593,10 @@ public class CasMerge
                     continue;
                 }
 
-                var sourceFsType = aAdapter.getAnnotationType(aSourceFs.getCAS()).get();
-                var sourceFeature = sourceFsType.getFeatureByBaseName(feature.getName());
-
-                if (sourceFeature == null) {
-                    throw new IllegalStateException("Source CAS type [" + sourceFsType.getName()
-                            + "] does not define a feature named [" + feature.getName() + "]");
-                }
+                FeatureUtil.getFeature(sourceFsType, feature)
+                        .orElseThrow(() -> new IllegalStateException("Source CAS type ["
+                                + sourceFsType.getName() + "] does not define a feature named ["
+                                + feature.getName() + "]"));
 
                 if (!aAdapter.getFeatureSupport(feature.getName())
                         .map(fs -> fs.isCopyOnCurationMerge(feature)).orElse(false)) {

--- a/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureSupport.java
+++ b/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureSupport.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.annotation.feature.link;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.WITH_ROLE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode.ARRAY;
+import static de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil.getFeature;
 import static de.tudarmstadt.ukp.inception.schema.api.feature.MaterializedLink.toMaterializedLink;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.CollectionUtils.disjunction;
@@ -214,7 +215,7 @@ public class LinkFeatureSupport
     @Override
     public List<LinkWithRoleModel> getFeatureValue(AnnotationFeature aFeature, FeatureStructure aFS)
     {
-        var linkFeature = aFS.getType().getFeatureByBaseName(aFeature.getName());
+        var linkFeature = getFeature(aFS, aFeature).orElse(null);
         if (linkFeature == null) {
             return emptyList();
         }

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -69,6 +69,7 @@ import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureEditor;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureType;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 
 /**
  * <p>
@@ -191,6 +192,8 @@ public class MultiValueStringFeatureSupport
             schemaService.createMissingTag(aFeature, value);
         }
 
+        var feature = FeatureUtil.getMandatoryFeature(fs, aFeature);
+
         // Create a new array if size differs otherwise re-use existing one
         var array = FSUtil.getFeature(fs, aFeature.getName(), StringArrayFS.class);
         if (array == null || (array.size() != values.size())) {
@@ -200,7 +203,7 @@ public class MultiValueStringFeatureSupport
         // Fill in links
         array.copyFromArray(values.toArray(new String[values.size()]), 0, 0, values.size());
 
-        fs.setFeatureValue(fs.getType().getFeatureByBaseName(aFeature.getName()), array);
+        fs.setFeatureValue(feature, array);
     }
 
     @Override
@@ -221,7 +224,7 @@ public class MultiValueStringFeatureSupport
             schemaService.createMissingTag(aFeature, value);
         }
 
-        var feature = fs.getType().getFeatureByBaseName(aFeature.getName());
+        var feature = FeatureUtil.getMandatoryFeature(fs, aFeature);
         var oldValues = FSUtil.getFeature(fs, aFeature.getName(), StringArrayFS.class);
 
         var mergedValues = new LinkedHashSet<String>();
@@ -355,9 +358,7 @@ public class MultiValueStringFeatureSupport
     @Override
     public List<String> renderFeatureValues(AnnotationFeature aFeature, FeatureStructure aFs)
     {
-        var labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
-
-        if (labelFeature == null) {
+        if (FeatureUtil.getFeature(aFs, aFeature).isEmpty()) {
             return emptyList();
         }
 
@@ -398,7 +399,7 @@ public class MultiValueStringFeatureSupport
     {
         Object value;
 
-        var f = aFS.getType().getFeatureByBaseName(aFeature.getName());
+        var f = FeatureUtil.getFeature(aFS, aFeature).orElse(null);
 
         if (f == null) {
             value = null;

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/pivot/StringFeatureExtractor.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/pivot/StringFeatureExtractor.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.string.pivot;
 
+import static de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil.getFeature;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 import org.apache.uima.cas.FeatureStructure;
@@ -46,8 +47,10 @@ public class StringFeatureExtractor
     public String extract(ContextualizedFS<FeatureStructure> aAnn)
     {
         var ann = aAnn.fs();
-        var f = ann.getType().getFeatureByBaseName(feature.getName());
-        return trimToNull(ann.getFeatureValueAsString(f));
+        // The feature may be missing if the CAS has not been upgraded yet - treat it as no value
+        return getFeature(ann, feature) //
+                .map(f -> trimToNull(ann.getFeatureValueAsString(f))) //
+                .orElse(null);
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
@@ -61,6 +61,7 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 
 public class MetadataSuggestionSupport
     extends SuggestionSupport_ImplBase
@@ -196,9 +197,7 @@ public class MetadataSuggestionSupport
         var adapter = schemaService.getAdapter(aLayer);
         var traits = adapter.getTraits(DocumentMetadataLayerTraits.class).get();
         for (var feature : schemaService.listSupportedFeatures(aLayer)) {
-            var feat = predictedType.getFeatureByBaseName(feature.getName());
-
-            if (feat == null) {
+            if (FeatureUtil.getFeature(predictedType, feature).isEmpty()) {
                 // The feature does not exist in the type system of the CAS. Probably it has not
                 // been upgraded to the latest version of the type system yet. If this is the case,
                 // we'll just skip this feature.

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -110,6 +110,7 @@ import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.schema.api.feature.TypeUtil;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistry;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxEventBehavior;
@@ -652,9 +653,15 @@ public class DocumentMetadataAnnotationSelectionPanel
                 if (!feature.isEnabled()) {
                     continue;
                 }
+
+                if (!adapter.isFeatureDeclared(fs, feature)) {
+                    continue;
+                }
+
                 if (constraintsEvaluator.isHiddenConditionalFeature(constraints, fs, feature)) {
                     continue;
                 }
+
                 if (!adapter.isFeatureValueValid(feature, fs)) {
                     invalidFeatures.add(feature.getUiName());
                 }
@@ -913,10 +920,10 @@ public class DocumentMetadataAnnotationSelectionPanel
                 var sourceType = aAdapter.getAnnotationType(aSourceAnnotation.getCAS())
                         .orElseThrow(() -> new IllegalStateException(
                                 "Source CAS does not define the document metadata type"));
-                if (sourceType.getFeatureByBaseName(feature.getName()) == null) {
-                    throw new IllegalStateException("Source CAS type [" + sourceType.getName()
-                            + "] does not define a feature named [" + feature.getName() + "]");
-                }
+                FeatureUtil.getFeature(sourceType, feature)
+                        .orElseThrow(() -> new IllegalStateException("Source CAS type ["
+                                + sourceType.getName() + "] does not define a feature named ["
+                                + feature.getName() + "]"));
 
                 if (!aAdapter.getFeatureSupport(feature.getName())
                         .map(fs -> fs.isCopyOnCurationMerge(feature)).orElse(false)) {

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/pivot/RelationEndpointRangeExtractor.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/pivot/RelationEndpointRangeExtractor.java
@@ -24,6 +24,7 @@ import org.apache.uima.cas.text.AnnotationFS;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.AnnotationExtractor_ImplBase;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.ContextualizedFS;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 
 public class RelationEndpointRangeExtractor
     extends AnnotationExtractor_ImplBase<AnnotationFS, String>
@@ -57,7 +58,7 @@ public class RelationEndpointRangeExtractor
                 return false;
             }
 
-            return type.getFeatureByBaseName(feature.getName()) != null;
+            return FeatureUtil.getFeature(type, feature).isPresent();
         }
 
         return false;
@@ -67,8 +68,12 @@ public class RelationEndpointRangeExtractor
     public String extract(ContextualizedFS<AnnotationFS> aAnn)
     {
         var ann = aAnn.fs();
-        var f = ann.getType().getFeatureByBaseName(feature.getName());
-        var a = (AnnotationFS) ann.getFeatureValue(f);
+        var f = FeatureUtil.getFeature(ann, feature);
+        if (f.isEmpty()) {
+            return null;
+        }
+
+        var a = (AnnotationFS) ann.getFeatureValue(f.get());
         return a != null ? a.getBegin() + "-" + a.getEnd() : null;
     }
 

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/ArcSuggestionSupport_ImplBase.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/ArcSuggestionSupport_ImplBase.java
@@ -49,6 +49,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationPosition;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 
 public abstract class ArcSuggestionSupport_ImplBase
     extends SuggestionSupport_ImplBase
@@ -121,14 +122,16 @@ public abstract class ArcSuggestionSupport_ImplBase
         }
 
         for (var feature : schemaService.listSupportedFeatures(aLayer)) {
-            var feat = type.getFeatureByBaseName(feature.getName());
+            var maybeFeat = FeatureUtil.getFeature(type, feature);
 
-            if (feat == null) {
+            if (maybeFeat.isEmpty()) {
                 // The feature does not exist in the type system of the CAS. Probably it has not
                 // been upgraded to the latest version of the type system yet. If this is the case,
                 // we'll just skip this feature.
                 continue;
             }
+
+            var feat = maybeFeat.get();
 
             for (var group : groupedSuggestions) {
                 if (!feature.getName().equals(group.getFeature())) {

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupport.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupport.java
@@ -86,6 +86,7 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.support.text.TrimUtils;
 
 public class SpanSuggestionSupport
@@ -242,14 +243,16 @@ public class SpanSuggestionSupport
                 aDataOwner, aLayer);
 
         for (var feature : schemaService.listSupportedFeatures(aLayer)) {
-            var feat = type.getFeatureByBaseName(feature.getName());
+            var maybeFeat = FeatureUtil.getFeature(type, feature);
 
-            if (feat == null) {
+            if (maybeFeat.isEmpty()) {
                 // The feature does not exist in the type system of the CAS. Probably it has not
                 // been upgraded to the latest version of the type system yet. If this is the case,
                 // we'll just skip this feature.
                 continue;
             }
+
+            var feat = maybeFeat.get();
 
             // Reduce the suggestions to the ones for the given feature. We can use the tree here
             // since we only have a single SuggestionGroup for every position

--- a/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRendererTest.java
+++ b/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRendererTest.java
@@ -23,9 +23,15 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.OVERLAP_ONLY;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.STACKING_ONLY;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
+import java.util.Optional;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,11 +41,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanCrossSentenceBehavior;
 import de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanOverlapBehavior;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
@@ -113,6 +121,46 @@ public class SpanRendererTest
                 .usingRecursiveFieldByFieldElementComparator() //
                 .containsExactlyInAnyOrder(new VComment(ne, VCommentType.ERROR,
                         "Crossing sentence boundaries is not permitted."));
+    }
+
+    @Test
+    public void thatRenderToleratesFeatureMissingFromCas() throws Exception
+    {
+        // A feature that the project declares on the layer but which does not exist in the CAS -
+        // this happens when the CAS has not been upgraded to the current project type system, e.g.
+        // when opening a document read-only. See issue #6183.
+        var missingFeature = new AnnotationFeature(1l, neLayer, "comment", CAS.TYPE_NAME_STRING);
+        missingFeature.setRequired(true);
+
+        // Use the real feature support so that we exercise the actual feature value lookup which
+        // is what fails on a CAS that does not declare the feature
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var asWild = (Optional) Optional.of(new StringFeatureSupport());
+        lenient().when(featureSupportRegistry.findExtension(any(AnnotationFeature.class)))
+                .thenReturn(asWild);
+
+        jcas.setDocumentText(StringUtils.repeat("a", 10));
+
+        new Sentence(jcas, 0, 10).addToIndexes();
+        var ne = new NamedEntity(jcas, 3, 8);
+        ne.addToIndexes();
+
+        var features = asList(missingFeature);
+
+        var adapter = new SpanAdapterImpl(layerSupportRegistry, featureSupportRegistry, null,
+                neLayer, () -> features, asList(), constraintsService);
+
+        var sut = new SpanRenderer(adapter, layerSupportRegistry, featureSupportRegistry, asList());
+
+        var request = RenderRequest.builder() //
+                .withCas(jcas.getCas()) //
+                .withWindow(0, jcas.getCas().getDocumentText().length()) //
+                .build();
+        var vdoc = new VDocument(jcas.getCas().getDocumentText());
+
+        assertThatNoException().isThrownBy(() -> sut.render(request, features, vdoc));
+
+        assertThat(vdoc.comments()).isEmpty();
     }
 
     @Test

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionTask.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionTask.java
@@ -49,6 +49,7 @@ import de.tudarmstadt.ukp.inception.recommendation.tasks.RecommendationTask_Impl
 import de.tudarmstadt.ukp.inception.scheduling.ProjectTask;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
 public class TagSetExtractionTask
@@ -179,7 +180,12 @@ public class TagSetExtractionTask
             return;
         }
 
-        var uimaFeature = uimaType.getFeatureByBaseName(feature.getName());
+        var maybeUimaFeature = FeatureUtil.getFeature(uimaType, feature);
+        if (maybeUimaFeature.isEmpty()) {
+            return;
+        }
+
+        var uimaFeature = maybeUimaFeature.get();
         if (!supportedTypes.contains(uimaFeature.getRange().getName())) {
             return;
         }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
@@ -169,6 +169,10 @@ public interface Renderer
                 continue;
             }
 
+            if (!adapter.isFeatureDeclared(aFS, feature)) {
+                continue;
+            }
+
             if (evaluator.isHiddenConditionalFeature(constraits, aFS, feature)) {
                 continue;
             }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/adapter/TypeAdapter.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/adapter/TypeAdapter.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
@@ -43,6 +44,7 @@ import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupport;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
 /**
@@ -75,6 +77,84 @@ public interface TypeAdapter
     default Optional<Type> getAnnotationType(CAS aCas)
     {
         return Optional.ofNullable(aCas.getTypeSystem().getType(getAnnotationTypeName()));
+    }
+
+    /**
+     * Checks whether the type of this {@link TypeAdapter} is declared in the given CAS. This may
+     * not be the case if the CAS has not been upgraded to the current version of the project type
+     * system.
+     *
+     * @param aCas
+     *            the CAS.
+     * @return whether the type is declared in the CAS.
+     */
+    default boolean isTypeDeclared(CAS aCas)
+    {
+        return getAnnotationType(aCas).isPresent();
+    }
+
+    /**
+     * Get the CAS feature with the given name on the type of this {@link TypeAdapter}.
+     *
+     * @param aCas
+     *            the CAS.
+     * @param aFeatureName
+     *            the short name of the feature.
+     * @return the CAS feature or empty if either the type or the feature is not declared in the
+     *         CAS.
+     */
+    default Optional<Feature> getFeature(CAS aCas, String aFeatureName)
+    {
+        return getAnnotationType(aCas).map(type -> type.getFeatureByBaseName(aFeatureName));
+    }
+
+    /**
+     * Get the CAS feature corresponding to the given layer feature on the type of this
+     * {@link TypeAdapter}.
+     *
+     * @param aCas
+     *            the CAS.
+     * @param aFeature
+     *            the layer feature.
+     * @return the CAS feature or empty if either the type or the feature is not declared in the
+     *         CAS.
+     */
+    default Optional<Feature> getFeature(CAS aCas, AnnotationFeature aFeature)
+    {
+        return getFeature(aCas, aFeature.getName());
+    }
+
+    /**
+     * Get the CAS feature corresponding to the given layer feature on the type of the given feature
+     * structure. Note that this resolves the feature against the actual type of the feature
+     * structure which may be a sub-type of the type of this {@link TypeAdapter}.
+     *
+     * @param aFS
+     *            the feature structure.
+     * @param aFeature
+     *            the layer feature.
+     * @return the CAS feature or empty if the feature is not declared on the type of the feature
+     *         structure.
+     */
+    default Optional<Feature> getFeature(FeatureStructure aFS, AnnotationFeature aFeature)
+    {
+        return FeatureUtil.getFeature(aFS, aFeature);
+    }
+
+    /**
+     * Checks whether the given layer feature is declared on the type of the given feature
+     * structure. This may not be the case if the CAS has not been upgraded to the current version
+     * of the project type system.
+     *
+     * @param aFS
+     *            the feature structure.
+     * @param aFeature
+     *            the layer feature.
+     * @return whether the feature is declared on the type of the feature structure.
+     */
+    default boolean isFeatureDeclared(FeatureStructure aFS, AnnotationFeature aFeature)
+    {
+        return getFeature(aFS, aFeature).isPresent();
     }
 
     /**

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
@@ -276,12 +276,13 @@ public interface FeatureSupport<T>
      */
     default List<String> renderFeatureValues(AnnotationFeature aFeature, FeatureStructure aFs)
     {
-        var labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
-        if (labelFeature == null) {
+        var maybeLabelFeature = FeatureUtil.getFeature(aFs, aFeature);
+        if (maybeLabelFeature.isEmpty()) {
             return emptyList();
         }
 
-        var featureValue = renderFeatureValue(aFeature, aFs.getFeatureValueAsString(labelFeature));
+        var featureValue = renderFeatureValue(aFeature,
+                aFs.getFeatureValueAsString(maybeLabelFeature.get()));
         if (featureValue == null) {
             return emptyList();
         }
@@ -363,7 +364,7 @@ public interface FeatureSupport<T>
     {
         Object value;
 
-        var f = aFS.getType().getFeatureByBaseName(aFeature.getName());
+        var f = FeatureUtil.getFeature(aFS, aFeature).orElse(null);
 
         if (f == null) {
             value = getNullFeatureValue(aFeature, aFS);
@@ -503,12 +504,9 @@ public interface FeatureSupport<T>
     default FeatureStructure getFS(CAS aCas, AnnotationFeature aFeature, int aAddress)
     {
         var fs = selectFsByAddr(aCas, aAddress);
-        var feature = fs.getType().getFeatureByBaseName(aFeature.getName());
 
-        if (feature == null) {
-            throw new IllegalArgumentException("On [" + fs.getType().getName() + "] the feature ["
-                    + aFeature.getName() + "] does not exist.");
-        }
+        FeatureUtil.getMandatoryFeature(fs, aFeature);
+
         return fs;
     }
 

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureUtil.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureUtil.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.uima.cas.ArrayFS;
@@ -36,6 +37,58 @@ import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
 
 public class FeatureUtil
 {
+    /**
+     * Get the CAS feature corresponding to the given layer feature on the given type. The feature
+     * may be missing if the CAS has not been upgraded to the current version of the project type
+     * system.
+     *
+     * @param aType
+     *            the type.
+     * @param aFeature
+     *            the layer feature.
+     * @return the CAS feature or empty if the feature is not declared on the type.
+     */
+    public static Optional<Feature> getFeature(Type aType, AnnotationFeature aFeature)
+    {
+        return Optional.ofNullable(aType.getFeatureByBaseName(aFeature.getName()));
+    }
+
+    /**
+     * Get the CAS feature corresponding to the given layer feature on the type of the given feature
+     * structure. The feature may be missing if the CAS has not been upgraded to the current version
+     * of the project type system.
+     *
+     * @param aFS
+     *            the feature structure.
+     * @param aFeature
+     *            the layer feature.
+     * @return the CAS feature or empty if the feature is not declared on the type of the feature
+     *         structure.
+     */
+    public static Optional<Feature> getFeature(FeatureStructure aFS, AnnotationFeature aFeature)
+    {
+        return getFeature(aFS.getType(), aFeature);
+    }
+
+    /**
+     * Get the CAS feature corresponding to the given layer feature on the type of the given feature
+     * structure, failing if the feature is not declared.
+     *
+     * @param aFS
+     *            the feature structure.
+     * @param aFeature
+     *            the layer feature.
+     * @return the CAS feature.
+     * @throws IllegalArgumentException
+     *             if the feature is not declared on the type of the feature structure.
+     */
+    public static Feature getMandatoryFeature(FeatureStructure aFS, AnnotationFeature aFeature)
+    {
+        return getFeature(aFS, aFeature)
+                .orElseThrow(() -> new IllegalArgumentException("On [" + aFS.getType().getName()
+                        + "] the feature [" + aFeature.getName() + "] does not exist."));
+    }
+
     /**
      * Set a feature value.
      *
@@ -53,12 +106,7 @@ public class FeatureUtil
             return;
         }
 
-        var feature = aFS.getType().getFeatureByBaseName(aFeature.getName());
-
-        if (feature == null) {
-            throw new IllegalArgumentException("On [" + aFS.getType().getName() + "] the feature ["
-                    + aFeature.getName() + "] does not exist.");
-        }
+        var feature = getMandatoryFeature(aFS, aFeature);
 
         switch (aFeature.getMultiValueMode()) {
         case NONE: {

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/TypeUtil.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/TypeUtil.java
@@ -187,8 +187,12 @@ public final class TypeUtil
                 continue;
             }
 
-            var labelFeature = aFs.getType().getFeatureByBaseName(feature.getName());
-            var label = defaultString(aFs.getFeatureValueAsString(labelFeature));
+            var maybeLabelFeature = FeatureUtil.getFeature(aFs, feature);
+            if (maybeLabelFeature.isEmpty()) {
+                continue;
+            }
+
+            var label = defaultString(aFs.getFeatureValueAsString(maybeLabelFeature.get()));
 
             if (bratLabelText.length() > 0 && label.length() > 0) {
                 bratLabelText.append(TypeAdapter.FEATURE_SEPARATOR);

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/PrimitiveUimaIndexingSupport.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/PrimitiveUimaIndexingSupport.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.search.config.SearchServiceAutoConfiguration;
 
 /**
@@ -113,14 +114,9 @@ public class PrimitiveUimaIndexingSupport
         }
 
         if (TYPE_NAME_BOOLEAN.equals(aFeature.getType())) {
-            var booleanFeature = aAnnotation.getType().getFeatureByBaseName(aFeature.getName());
-            boolean value;
-            if (booleanFeature == null) {
-                value = false;
-            }
-            else {
-                value = aAnnotation.getBooleanValue(booleanFeature);
-            }
+            var value = FeatureUtil.getFeature(aAnnotation, aFeature) //
+                    .map(aAnnotation::getBooleanValue) //
+                    .orElse(false);
 
             var valuesMap = new HashSetValuedHashMap<String, String>();
             valuesMap.put(featureIndexName, value ? "true" : "false");

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -107,6 +107,7 @@ import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.api.config.AnnotationSchemaProperties;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.schema.api.feature.LinkWithRoleModel;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior;
@@ -1066,7 +1067,7 @@ public abstract class AnnotationDetailEditorPanel
                 continue;
             }
 
-            if (aFS != null && aFS.getType().getFeatureByBaseName(feature.getName()) == null) {
+            if (aFS != null && FeatureUtil.getFeature(aFS, feature).isEmpty()) {
                 error("The annotation typesystem seems to be out of date, try re-opening the document!");
                 LOG.error("Unable to find [{}] in the current CAS typesystem", feature.getName());
                 aTarget.addChildren(getPage(), IFeedback.class);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
@@ -228,6 +228,10 @@ public class CurationSidebarRenderer
                     if (!feature.isEnabled()) {
                         continue;
                     }
+
+                    if (!adapter.isFeatureDeclared(ann, feature)) {
+                        continue;
+                    }
                     if (constraintsEvaluator.isHiddenConditionalFeature(constraints, ann,
                             feature)) {
                         continue;

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
@@ -65,6 +65,7 @@ import de.tudarmstadt.ukp.inception.schema.api.adapter.IllegalFeatureValueExcept
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureEditor;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupport;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureType;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import de.tudarmstadt.ukp.inception.ui.kb.config.KnowledgeBaseServiceUIAutoConfiguration;
 
@@ -154,7 +155,7 @@ public class MultiValueConceptFeatureSupport
             return;
         }
 
-        var feature = fs.getType().getFeatureByBaseName(aFeature.getName());
+        var feature = FeatureUtil.getMandatoryFeature(fs, aFeature);
         var oldValues = FSUtil.getFeature(fs, aFeature.getName(), StringArrayFS.class);
 
         var mergedValues = new LinkedHashSet<String>();
@@ -373,6 +374,8 @@ public class MultiValueConceptFeatureSupport
             return;
         }
 
+        var feature = FeatureUtil.getMandatoryFeature(fs, aFeature);
+
         // Create a new array if size differs otherwise re-use existing one
         StringArrayFS array = FSUtil.getFeature(fs, aFeature.getName(), StringArrayFS.class);
         if (array == null || (array.size() != values.size())) {
@@ -382,7 +385,7 @@ public class MultiValueConceptFeatureSupport
         // Fill in links
         array.copyFromArray(values.toArray(new String[values.size()]), 0, 0, values.size());
 
-        fs.setFeatureValue(fs.getType().getFeatureByBaseName(aFeature.getName()), array);
+        fs.setFeatureValue(feature, array);
     }
 
     @Override
@@ -405,9 +408,7 @@ public class MultiValueConceptFeatureSupport
     @Override
     public List<String> renderFeatureValues(AnnotationFeature aFeature, FeatureStructure aFs)
     {
-        var labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
-
-        if (labelFeature == null) {
+        if (FeatureUtil.getFeature(aFs, aFeature).isEmpty()) {
             return emptyList();
         }
 


### PR DESCRIPTION
**What's in the PR**
- Add isTypeDeclared/isFeatureDeclared helpers to TypeAdapter for safe type/feature existence checking in CAS that may lack current type system
- Add getFeature/getMandatoryFeature statics to FeatureUtil as shared bridge between AnnotationFeature schema and UIMA Feature lookups
- Refactor ~25 hand-rolled getFeatureByBaseName bridge sites across feature/adapter/recommender/merge/indexing modules onto the FeatureUtil helpers
- Fix missing-feature tolerance in read-only render paths (Renderer.renderRequiredFeatureErrors, CurationSidebarRenderer, DocumentMetadataPanel, AnnotationPageBase validation loop)
- Fix four latent NPE/crashes where feature lookups were dereferenced without null guards (TypeUtil label-text, StringFeatureExtractor, RelationEndpointRangeExtractor, TagSetExtractionTask)
- Fix CasMerge type-lookup bare .get() by hoisting out of loop and adding proper error handling
- Add regression test thatRenderToleratesFeatureMissingFromCas to SpanRendererTest

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
