### PR TITLE
#6198 - Startup warnings about Vector API and restricted Linker method when running the standalone JAR

### DIFF
--- a/inception/inception-dist-docker/src/main/docker/Dockerfile
+++ b/inception/inception-dist-docker/src/main/docker/Dockerfile
@@ -60,4 +60,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD ["sh", "-c", "curl -sf http://localhost:8080/actuator/health | jq -e '.status==\"UP\"' || exit 1"]
 
 # Launch application
-CMD ["sh", "-c", "/opt/inception/launch.sh java ${JAVA_MEM_OPTS} ${JAVA_OPTS} --add-modules jdk.incubator.vector -Djava.awt.headless=true -Dinception.home=/export -jar inception-app-standalone.jar ${APP_ARGS}"]
+CMD ["sh", "-c", "/opt/inception/launch.sh java ${JAVA_MEM_OPTS} ${JAVA_OPTS} --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Djava.awt.headless=true -Dinception.home=/export -jar inception-app-standalone.jar ${APP_ARGS}"]

--- a/inception/inception-dist-macos/src/main/scripts/package-dmg.sh
+++ b/inception/inception-dist-macos/src/main/scripts/package-dmg.sh
@@ -99,6 +99,8 @@ echo "Building ${TARGET_ARCH} DMG via $JPACKAGE..."
   --main-class "$MAIN_CLASS" \
   --java-options -Xmx4g \
   --java-options -Dinception.app-bundle=true \
+  --java-options "--add-modules jdk.incubator.vector" \
+  --java-options "--enable-native-access=ALL-UNNAMED" \
   --icon "$ICON" \
   --mac-sign \
   --mac-signing-key-user-name "$SIGNING_IDENTITY" \

--- a/inception/inception-dist-win/src/main/scripts/package-msi.sh
+++ b/inception/inception-dist-win/src/main/scripts/package-msi.sh
@@ -95,6 +95,8 @@ echo "Building ${TARGET_ARCH} MSI via $JPACKAGE..."
   --main-class "$MAIN_CLASS" \
   --java-options -Xmx4g \
   --java-options -Dinception.app-bundle=true \
+  --java-options "--add-modules jdk.incubator.vector" \
+  --java-options "--enable-native-access=ALL-UNNAMED" \
   --icon "$ICON" \
   --win-dir-chooser \
   --win-menu \

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_jar.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_jar.adoc
@@ -33,8 +33,12 @@ Note the change of the filename to `inception.jar`.
 +
 [source,text]
 ----
-JAVA_OPTS="-Djava.awt.headless=true -Dinception.home=/srv/inception"
+JAVA_OPTS="-Djava.awt.headless=true -Dinception.home=/srv/inception --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED"
 ----
++
+NOTE: The `--add-modules` and `--enable-native-access` options are used by the search index.
+Without them, {product-name} still works, but it logs warnings during startup and the vector
+search runs more slowly. See <<sect_jvm_options>> for details.
 +
 * In the previous step, you have already created the `/srv/inception/settings.properties` file.
 You *may optionally* configure the Tomcat port using the following line
@@ -108,6 +112,32 @@ $ systemctl stop inception
 ----
 
 NOTE: If you encounter strange errors, e.g. `+{status=203/EXEC}+`  and INCEpTION starts when directly executing the jar but not via systemd, then we recommend to disable SELinux.
+
+[[sect_jvm_options]]
+== Recommended JVM options
+
+The search index (Apache Lucene) uses two modern JVM facilities that must be explicitly enabled.
+Both options are JVM options, so they need to appear *before* the `-jar` argument on the command
+line. In the service file shown above, `$JAVA_OPTS` is already placed accordingly, so adding them
+to `inception.conf` is sufficient.
+
+`--add-modules jdk.incubator.vector`::
+  Enables the Vector API which is used to speed up vector-based (semantic) search. Without it,
+  {product-name} logs `Java vector incubator module is not readable` during startup and falls back
+  to a slower implementation. As the name suggests, this is still an *incubator* module and it must
+  therefore be enabled explicitly.
+
+`--enable-native-access=ALL-UNNAMED`::
+  Permits the use of the foreign function and memory API which is used to access the index files.
+  Without it, the JVM prints a `WARNING: A restricted method in java.lang.foreign.Linker has been
+  called` message during startup. Note that future Java versions are expected to turn this warning
+  into an error.
++
+NOTE: `ALL-UNNAMED` is required here because {product-name} is started from an executable JAR, so
+all classes are loaded into the unnamed module and the permission cannot be narrowed down further.
+
+The {product-name} Docker image as well as the Windows and macOS installers already set these
+options. They only need to be configured manually when running the standalone JAR.
 
 == Loading extra Java libraries
 


### PR DESCRIPTION
**What's in the PR**
- Enable Vector API and restricted native access JVM options across all distribution formats (Docker, Windows MSI, macOS DMG, and standalone JAR) to suppress startup warnings and optimize vector-based search performance
- Add documentation section explaining the `--add-modules` and `--enable-native-access` JVM options required by the search index

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
