### PR TITLE
#3457 - Allow remote API to use project slugs

### DIFF
--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroAnnotationController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroAnnotationController.java
@@ -83,9 +83,10 @@ public class AeroAnnotationController
     public ResponseEntity<RResponse<List<RAnnotation>>> list( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.
@@ -117,9 +118,10 @@ public class AeroAnnotationController
     public ResponseEntity<RResponse<RAnnotation>> create( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.
@@ -198,9 +200,10 @@ public class AeroAnnotationController
     public ResponseEntity<byte[]> read( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.
@@ -236,9 +239,10 @@ public class AeroAnnotationController
     public ResponseEntity<RResponse<Void>> delete( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroCurationController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroCurationController.java
@@ -88,9 +88,10 @@ public class AeroCurationController
     public ResponseEntity<RResponse<RAnnotation>> create( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.
@@ -175,9 +176,10 @@ public class AeroCurationController
     public ResponseEntity<byte[]> read( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.
@@ -209,9 +211,10 @@ public class AeroCurationController
     public ResponseEntity<RResponse<Void>> delete( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroDocumentController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroDocumentController.java
@@ -96,9 +96,10 @@ public class AeroDocumentController
     public ResponseEntity<RResponse<List<RDocument>>> list( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId)
+            String aProjectId)
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
@@ -122,9 +123,10 @@ public class AeroDocumentController
     public ResponseEntity<RResponse<RDocument>> create( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @RequestParam(PARAM_NAME) //
             @Schema(description = """
                     Document name.
@@ -223,9 +225,10 @@ public class AeroDocumentController
     public ResponseEntity<?> read( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.
@@ -323,9 +326,10 @@ public class AeroDocumentController
     public ResponseEntity<RResponse<Void>> delete( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroKnowledgeBaseController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroKnowledgeBaseController.java
@@ -77,9 +77,10 @@ public class AeroKnowledgeBaseController
     public ResponseEntity<RResponse<List<RKnowledgeBase>>> list( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId)
+            String aProjectId)
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
@@ -109,9 +110,10 @@ public class AeroKnowledgeBaseController
     public ResponseEntity<String> sparqlOne( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_KNOWLEDGE_BASE_ID) //
             @Schema(description = """
                     Knowledge base identifier.
@@ -164,9 +166,10 @@ public class AeroKnowledgeBaseController
     public ResponseEntity<String> sparqlAll( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @RequestBody //
             @Schema(description = """
                     SPARQL query.

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectController.java
@@ -122,11 +122,19 @@ public class AeroProjectController
             consumes = { ALL_VALUE, MULTIPART_FORM_DATA_VALUE }, //
             produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<RProject>> create( //
-            @RequestParam(PARAM_NAME) //
+            @RequestParam(PARAM_SLUG) //
             @Schema(description = """
                     URL slug of the project. This is used to create a URL for the project.
+                    Exactly one of `slug` or the deprecated `name` must be provided.
                     """) //
-            String aSlug, //
+            Optional<String> aSlugParam, //
+            @RequestParam(PARAM_NAME) //
+            @Schema(description = """
+                    URL slug of the project. Deprecated - use `slug` instead. Note that this
+                    parameter sets the slug and not the human-readable project name which is
+                    set via `title`.
+                    """, deprecated = true) //
+            Optional<String> aNameParam, //
             @RequestParam(PARAM_TITLE) //
             @Schema(description = """
                     Name of the project. It not specified, the slug will be used as the name.
@@ -143,6 +151,21 @@ public class AeroProjectController
             UriComponentsBuilder aUcb)
         throws Exception
     {
+        // The slug used to be passed via the "name" parameter which is confusing since the
+        // human-readable project name is passed via "title". Thus, "slug" is preferred nowadays
+        // while "name" is still accepted for backwards compatibility.
+        if (aSlugParam.isPresent() && aNameParam.isPresent()) {
+            throw new IllegalNameException(
+                    "Only one of the parameters [%s] and [%s] can be used at the same time - "
+                            + "prefer [%s] as [%s] is deprecated.",
+                    PARAM_SLUG, PARAM_NAME, PARAM_SLUG, PARAM_NAME);
+        }
+
+        var aSlug = aSlugParam.or(() -> aNameParam)
+                .orElseThrow(() -> new IllegalNameException(
+                        "One of the parameters [%s] or [%s] must be provided.", PARAM_SLUG,
+                        PARAM_NAME));
+
         // Get current user - this will throw an exception if the current user does not exit
         var sessionOwner = getSessionOwner();
 
@@ -197,7 +220,13 @@ public class AeroProjectController
     @Operation(summary = "Get information about a project")
     @GetMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID
             + "}"), produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<RResponse<RProject>> read(@PathVariable(PARAM_PROJECT_ID) long aProjectId)
+    public ResponseEntity<RResponse<RProject>> read( //
+            @PathVariable(PARAM_PROJECT_ID) //
+            @Schema(description = """
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
+                    """) //
+            String aProjectId)
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
@@ -212,9 +241,10 @@ public class AeroProjectController
     public ResponseEntity<RResponse<Void>> delete( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId)
+            String aProjectId)
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
@@ -323,9 +353,10 @@ public class AeroProjectController
     public ResponseEntity<InputStreamResource> download( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @RequestParam(value = PARAM_FORMAT) //
             @Schema(description = """
                     If this parameter is specified, the project export will include a second copy

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RProject.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RProject.java
@@ -18,17 +18,44 @@
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public class RProject
 {
+    @Schema(description = """
+            Numeric project identifier. Can be used in place of the slug when addressing the
+            project in API paths.
+            """)
     public long id;
+
+    /**
+     * @deprecated Use {@link #slug} instead. This field carries the project slug, not the
+     *             human-readable project name - the latter is available as {@link #title}.
+     */
+    @Deprecated
+    @Schema(description = """
+            URL slug of the project. Deprecated - use `slug` instead. Note that this field
+            carries the slug and not the human-readable project name which is available as
+            `title`.
+            """)
     public String name;
+
+    @Schema(description = """
+            URL slug of the project. Can be used in place of the numeric ID when addressing
+            the project in API paths.
+            """)
+    public String slug;
+
+    @Schema(description = """
+            Human-readable name of the project.
+            """)
     public String title;
 
     public RProject(Project aProject)
     {
         id = aProject.getId();
         name = aProject.getSlug();
+        slug = aProject.getSlug();
         title = aProject.getName();
     }
 
@@ -37,6 +64,7 @@ public class RProject
         super();
         id = aId;
         name = aSlug;
+        slug = aSlug;
         title = aTitle;
     }
 }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/Controller_ImplBase.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/Controller_ImplBase.java
@@ -94,6 +94,7 @@ public abstract class Controller_ImplBase
     public static final String PARAM_FILE = "file";
     public static final String PARAM_CONTENT = "content";
     public static final String PARAM_NAME = "name";
+    public static final String PARAM_SLUG = "slug";
     public static final String PARAM_TITLE = "title";
     public static final String PARAM_FORMAT = "format";
     public static final String PARAM_STATE = "state";
@@ -178,10 +179,6 @@ public abstract class Controller_ImplBase
     protected Project getProject(long aProjectId)
         throws ObjectNotFoundException, AccessForbiddenException
     {
-        // Get current user - this will throw an exception if the current user does not exit
-        var sessionOwner = getSessionOwner();
-
-        // Get project
         Project project;
         try {
             project = projectService.getProject(aProjectId);
@@ -190,14 +187,69 @@ public abstract class Controller_ImplBase
             throw new ObjectNotFoundException("Project [" + aProjectId + "] not found.");
         }
 
+        return assertCanAccessProject(project, String.valueOf(aProjectId));
+    }
+
+    /**
+     * Look up a project either by its numeric ID or by its URL slug. Since a project slug can never
+     * start with a digit (cf. {@link Project#isValidProjectSlug}), a numeric identifier is
+     * unambiguously an ID and any other identifier is unambiguously a slug.
+     *
+     * @param aProjectId
+     *            the numeric project ID or the project slug.
+     * @return the project.
+     * @throws ObjectNotFoundException
+     *             if the project does not exist.
+     * @throws AccessForbiddenException
+     *             if the session owner may not access the project.
+     */
+    protected Project getProject(String aProjectId)
+        throws ObjectNotFoundException, AccessForbiddenException
+    {
+        var projectId = toProjectId(aProjectId);
+        if (projectId != null) {
+            return getProject(projectId.longValue());
+        }
+
+        Project project;
+        try {
+            project = projectService.getProjectBySlug(aProjectId);
+        }
+        catch (NoResultException e) {
+            throw new ObjectNotFoundException("Project [" + aProjectId + "] not found.");
+        }
+
+        return assertCanAccessProject(project, aProjectId);
+    }
+
+    /**
+     * @return the given identifier as a numeric project ID or {@code null} if it is not a
+     *         well-formed numeric ID and should hence be treated as a project slug.
+     */
+    private static Long toProjectId(String aProjectId)
+    {
+        try {
+            return Long.valueOf(aProjectId);
+        }
+        catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Project assertCanAccessProject(Project aProject, String aProjectId)
+        throws ObjectNotFoundException, AccessForbiddenException
+    {
+        // Get current user - this will throw an exception if the current user does not exit
+        var sessionOwner = getSessionOwner();
+
         // Check for the access
         assertPermission(
                 "User [" + sessionOwner.getUsername() + "] is not allowed to access project ["
                         + aProjectId + "]",
-                projectService.hasRole(sessionOwner, project, MANAGER)
+                projectService.hasRole(sessionOwner, aProject, MANAGER)
                         || userRepository.isAdministrator(sessionOwner));
 
-        return project;
+        return aProject;
     }
 
     protected SourceDocument getDocument(Project aProject, long aDocumentId)
@@ -239,7 +291,7 @@ public abstract class Controller_ImplBase
         }
     }
 
-    protected CAS createCompatibleCas(long aProjectId, long aDocumentId, MultipartFile aFile,
+    protected CAS createCompatibleCas(String aProjectId, long aDocumentId, MultipartFile aFile,
             Optional<String> aFormatId)
         throws RemoteApiException, ClassNotFoundException, IOException, UIMAException
     {
@@ -317,7 +369,7 @@ public abstract class Controller_ImplBase
         return annotationCas;
     }
 
-    protected ResponseEntity<byte[]> readAnnotation(long aProjectId, long aDocumentId,
+    protected ResponseEntity<byte[]> readAnnotation(String aProjectId, long aDocumentId,
             String aAnnotatorId, Mode aMode, Optional<String> aFormat)
         throws RemoteApiException, ClassNotFoundException, IOException, UIMAException
     {

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/AnnotationController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/AnnotationController.java
@@ -72,9 +72,10 @@ public class AnnotationController
     public ResponseEntity<RResponse<RAnnotation>> updateState( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_DOCUMENT_ID) //
             @Schema(description = """
                     Document identifier.

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/PermissionController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/PermissionController.java
@@ -67,9 +67,10 @@ public class PermissionController
     public ResponseEntity<RResponse<List<RPermission>>> read( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId)
+            String aProjectId)
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
@@ -99,9 +100,10 @@ public class PermissionController
     public ResponseEntity<RResponse<List<RPermission>>> read( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_ANNOTATOR_ID) //
             @Schema(description = """
                     User to list the permissions for.
@@ -138,9 +140,10 @@ public class PermissionController
     public ResponseEntity<RResponse<List<RPermission>>> create( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_ANNOTATOR_ID) //
             @Schema(description = """
                     User to assign the permissions to.
@@ -190,9 +193,10 @@ public class PermissionController
     public ResponseEntity<RResponse<List<RPermission>>> delete( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_ANNOTATOR_ID) //
             @Schema(description = """
                     User to assign the permissions to.

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskBulkPredictionController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskBulkPredictionController.java
@@ -88,9 +88,10 @@ public class TaskBulkPredictionController
     public ResponseEntity<RResponse<RTaskState>> create( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @RequestParam(PARAM_RECOMMENDER_NAME) //
             @Schema(description = """
                     Recommender name.
@@ -161,7 +162,7 @@ public class TaskBulkPredictionController
         return ResponseEntity.ok(new RResponse<>(new RTaskState(task)));
     }
 
-    private void assertRecommenderCanBeTriggered(long aProjectId, Recommender aRecommender)
+    private void assertRecommenderCanBeTriggered(String aProjectId, Recommender aRecommender)
     {
         if (!aRecommender.isEnabled()) {
             throw new IllegalArgumentException("Recommender [" + aRecommender.getName()
@@ -188,7 +189,7 @@ public class TaskBulkPredictionController
         }
     }
 
-    private HashMap<AnnotationFeature, Serializable> convertMetadata(long aProjectId,
+    private HashMap<AnnotationFeature, Serializable> convertMetadata(String aProjectId,
             List<RMetadataAnnotation> aMetadata, Project project)
     {
         var metadata = new HashMap<AnnotationFeature, Serializable>();

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskController.java
@@ -65,9 +65,10 @@ public class TaskController
     public ResponseEntity<RResponse<List<RTaskState>>> list( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId)
+            String aProjectId)
         throws Exception
     {
         var project = getProject(aProjectId);
@@ -91,9 +92,10 @@ public class TaskController
     public ResponseEntity<RResponse<Void>> cancel( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @PathVariable(PARAM_TASK_ID) //
             @Schema(description = """
                     Task identifier.

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/UserController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/UserController.java
@@ -74,9 +74,10 @@ public class UserController
     public ResponseEntity<RResponse<List<RUser>>> list( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId)
+            String aProjectId)
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
@@ -101,9 +102,10 @@ public class UserController
     public ResponseEntity<RResponse<RUser>> create( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @RequestParam(PARAM_NAME) //
             @Schema(description = """
                     Display name.
@@ -137,9 +139,10 @@ public class UserController
     public ResponseEntity<RResponse<RUser>> delete( //
             @PathVariable(PARAM_PROJECT_ID) //
             @Schema(description = """
-                    Project identifier.
+                    Project identifier - either the numeric project ID or the project
+                    URL slug.
                     """) //
-            long aProjectId, //
+            String aProjectId, //
             @RequestParam(PARAM_NAME) //
             @Schema(description = """
                     Display name.

--- a/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api.adoc
+++ b/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api.adoc
@@ -51,6 +51,30 @@ The API follows the link:https://openminted.github.io/releases/aero-spec/1.0.0/o
 
 The third-party Python library link:https://pycaprio.readthedocs.io/en/latest/[pycaprio] can be used to facilitate accessing the remote API.
 
+== Addressing projects
+
+Operations that work on a particular project accept either the numeric project ID or the project
+URL slug in the `projectId` path segment. The slug is the project identifier that also appears in
+the URL when working with the project in the web interface, which usually makes it the more
+convenient of the two. Thus, the following two requests are equivalent:
+
+```
+<APPLICATION_URL>/api/aero/v1/projects/42/documents
+<APPLICATION_URL>/api/aero/v1/projects/my-project/documents
+```
+
+There is no ambiguity between the two forms because a project slug can never consist only of
+digits - it always starts with a letter.
+
+The slug of a project is reported as the `slug` field by the project-related operations. For
+backwards compatibility, it is also still reported as the `name` field, but that field is
+deprecated. Mind that the human-readable project name is reported as the `title` field.
+
+Likewise, the operation for creating a project takes the slug via its `slug` parameter and the
+human-readable project name via its `title` parameter. The slug used to be passed via the `name`
+parameter which is still supported for backwards compatibility but deprecated. Providing both
+`slug` and `name` is rejected.
+
 == HTTP basic authentication
 
 .HTTP basic settings for the remote API

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroDocumentControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroDocumentControllerTest.java
@@ -134,6 +134,51 @@ public class AeroDocumentControllerTest
     }
 
     @Test
+    void testCreateListDeleteDocumentAddressingProjectBySlug() throws Exception
+    {
+        var documentName = "test.txt";
+
+        adminActor.importTextDocument("project1", documentName, "This is a test.") //
+                .andExpect(status().isCreated()) //
+                .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
+                .andExpect(jsonPath("$.body.id").value("1")) //
+                .andExpect(jsonPath("$.body.name").value(documentName));
+
+        adminActor.listDocuments("project1") //
+                .andExpect(status().isOk()) //
+                .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
+                .andExpect(jsonPath("$.body[0].id").value("1")) //
+                .andExpect(jsonPath("$.body[0].name").value(documentName));
+
+        // A document created via the slug must also be visible when addressing the project by ID
+        adminActor.listDocuments(1l) //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body[0].id").value("1"));
+
+        adminActor.exportTextDocument("project1", 1l) //
+                .andExpect(status().isOk()) //
+                .andExpect(content().contentType(TEXT_PLAIN_VALUE)) //
+                .andExpect(content().string("This is a test."));
+
+        adminActor.deleteDocument("project1", 1l) //
+                .andExpect(status().isOk());
+
+        adminActor.listDocuments("project1") //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body").isEmpty());
+    }
+
+    @Test
+    void thatNonManagerCannotImportDocumentsWhenAddressingProjectBySlug() throws Exception
+    {
+        adminActor.grantProjectRole(1, "user", "ANNOTATOR", "CURATOR") //
+                .andExpect(status().isOk());
+
+        userActor.importTextDocument("project1", "test.txt", "This is a test.") //
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void testImportExportDocument() throws Exception
     {
         var documentName = "test.txt";

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectControllerTest.java
@@ -125,6 +125,150 @@ public class AeroProjectControllerTest
                 .andExpect(jsonPath("$.messages").isEmpty());
     }
 
+    @Test
+    void testReadProjectByIdAndBySlug() throws Exception
+    {
+        adminActor.createProject("project1") //
+                .andExpect(status().isCreated()) //
+                .andExpect(jsonPath("$.body.id").value("1"));
+
+        adminActor.readProject(1l) //
+                .andExpect(status().isOk()) //
+                .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
+                .andExpect(jsonPath("$.body.id").value("1")) //
+                .andExpect(jsonPath("$.body.slug").value("project1"));
+
+        adminActor.readProject("project1") //
+                .andExpect(status().isOk()) //
+                .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
+                .andExpect(jsonPath("$.body.id").value("1")) //
+                .andExpect(jsonPath("$.body.slug").value("project1"));
+    }
+
+    @Test
+    void testReadProjectByUnknownSlugIsNotFound() throws Exception
+    {
+        adminActor.createProject("project1") //
+                .andExpect(status().isCreated());
+
+        adminActor.readProject("no-such-project") //
+                .andExpect(status().isNotFound()) //
+                .andExpect(jsonPath("$.messages[0].level").value("ERROR")) //
+                .andExpect(
+                        jsonPath("$.messages[0].message").value(containsString("no-such-project")));
+    }
+
+    @Test
+    void testReadProjectByUnknownIdIsNotFound() throws Exception
+    {
+        adminActor.createProject("project1") //
+                .andExpect(status().isCreated());
+
+        adminActor.readProject(9999l) //
+                .andExpect(status().isNotFound()) //
+                .andExpect(jsonPath("$.messages[0].level").value("ERROR"));
+    }
+
+    @Test
+    void testReadProjectByMalformedIdentifierIsNotFound() throws Exception
+    {
+        adminActor.createProject("project1") //
+                .andExpect(status().isCreated());
+
+        // These are all digit sequences which cannot be parsed as a numeric project ID. Since they
+        // are not valid slugs either, they must be reported as not found instead of causing an
+        // internal server error.
+        for (var identifier : new String[] { //
+                "99999999999999999999", // exceeds the long range
+                "٤٢", // Arabic-Indic digits
+                "-1" }) {
+            adminActor.readProject(identifier) //
+                    .andExpect(status().isNotFound()) //
+                    .andExpect(jsonPath("$.messages[0].level").value("ERROR"));
+        }
+    }
+
+    @Test
+    void testProjectResponseExposesSlugAndDeprecatedName() throws Exception
+    {
+        // Use a slug which differs from the title so that mixing up the two fields is actually
+        // detectable - "name" carries the slug for backwards compatibility while the
+        // human-readable project name is reported as "title".
+        adminActor.createProject("project-slug", "Project Title") //
+                .andExpect(status().isCreated()) //
+                .andExpect(jsonPath("$.body.slug").value("project-slug")) //
+                .andExpect(jsonPath("$.body.name").value("project-slug")) //
+                .andExpect(jsonPath("$.body.title").value("Project Title"));
+
+        adminActor.readProject("project-slug") //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body.slug").value("project-slug")) //
+                .andExpect(jsonPath("$.body.name").value("project-slug")) //
+                .andExpect(jsonPath("$.body.title").value("Project Title"));
+
+        adminActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body[0].slug").value("project-slug")) //
+                .andExpect(jsonPath("$.body[0].name").value("project-slug")) //
+                .andExpect(jsonPath("$.body[0].title").value("Project Title"));
+    }
+
+    @Test
+    void testCreateProjectUsingDeprecatedNameParameter() throws Exception
+    {
+        // The "name" parameter sets the slug - it is deprecated in favor of "slug" but must
+        // keep working for existing clients.
+        adminActor.createProjectUsingNameParameter("project-slug") //
+                .andExpect(status().isCreated()) //
+                .andExpect(jsonPath("$.body.slug").value("project-slug")) //
+                .andExpect(jsonPath("$.body.name").value("project-slug")) //
+                .andExpect(jsonPath("$.body.title").value("project-slug"));
+
+        adminActor.readProject("project-slug") //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body.slug").value("project-slug"));
+    }
+
+    @Test
+    void testCreateProjectWithBothSlugAndNameIsRejected() throws Exception
+    {
+        adminActor.createProjectUsingSlugAndNameParameters("project-slug", "other-slug") //
+                .andExpect(status().isBadRequest()) //
+                .andExpect(jsonPath("$.messages[0].level").value("ERROR"));
+
+        // Nothing must have been created
+        adminActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body").isEmpty());
+    }
+
+    @Test
+    void testCreateProjectWithoutSlugOrNameIsRejected() throws Exception
+    {
+        adminActor.createProjectWithoutSlugOrName() //
+                .andExpect(status().isBadRequest()) //
+                .andExpect(jsonPath("$.messages[0].level").value("ERROR"));
+
+        adminActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body").isEmpty());
+    }
+
+    @Test
+    void testDeleteProjectBySlug() throws Exception
+    {
+        adminActor.createProject("project1") //
+                .andExpect(status().isCreated());
+
+        adminActor.deleteProject("project1") //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.messages[0].message").value(containsString("deleted")));
+
+        adminActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body").isEmpty());
+    }
+
     @SpringBootConfiguration
     static class TestContext
     {

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/MockAeroClient.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/MockAeroClient.java
@@ -66,7 +66,7 @@ class MockAeroClient
         roles = aRoles;
     }
 
-    ResultActions importTextDocument(long aProjectId, String aName, String aContent)
+    ResultActions importTextDocument(Object aProjectId, String aName, String aContent)
         throws Exception
     {
         return mvc.perform(multipart(API_BASE + "/projects/" + aProjectId + "/documents")
@@ -77,7 +77,7 @@ class MockAeroClient
                 .param("format", "text"));
     }
 
-    ResultActions exportTextDocument(long aProjectId, long aDocId) throws Exception
+    ResultActions exportTextDocument(Object aProjectId, long aDocId) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/documents/" + aDocId)
                 .with(csrf().asHeader()) //
@@ -85,29 +85,73 @@ class MockAeroClient
                 .param("format", "text"));
     }
 
-    ResultActions deleteDocument(long aProjectId, long aDocId) throws Exception
+    ResultActions deleteDocument(Object aProjectId, long aDocId) throws Exception
     {
         return mvc.perform(delete(API_BASE + "/projects/" + aProjectId + "/documents/" + aDocId) //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions listDocuments(long aProjectId) throws Exception
+    ResultActions listDocuments(Object aProjectId) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/documents") //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions createProject(String aName) throws Exception
+    ResultActions createProject(String aSlug) throws Exception
     {
         return mvc.perform(post(API_BASE + "/projects") //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)) //
+                .param("slug", aSlug));
+    }
+
+    ResultActions createProject(String aSlug, String aTitle) throws Exception
+    {
+        return mvc.perform(post(API_BASE + "/projects") //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)) //
+                .param("slug", aSlug) //
+                .param("title", aTitle));
+    }
+
+    /**
+     * Create a project using the deprecated {@code name} parameter instead of {@code slug}.
+     */
+    ResultActions createProjectUsingNameParameter(String aSlug) throws Exception
+    {
+        return mvc.perform(post(API_BASE + "/projects") //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)) //
+                .param("name", aSlug));
+    }
+
+    ResultActions createProjectUsingSlugAndNameParameters(String aSlug, String aName)
+        throws Exception
+    {
+        return mvc.perform(post(API_BASE + "/projects") //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)) //
+                .param("slug", aSlug) //
                 .param("name", aName));
     }
 
-    ResultActions deleteProject(long aProjectId) throws Exception
+    ResultActions createProjectWithoutSlugOrName() throws Exception
+    {
+        return mvc.perform(post(API_BASE + "/projects") //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)));
+    }
+
+    ResultActions readProject(Object aProjectId) throws Exception
+    {
+        return mvc.perform(get(API_BASE + "/projects/" + aProjectId) //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)));
+    }
+
+    ResultActions deleteProject(Object aProjectId) throws Exception
     {
         return mvc.perform(delete(API_BASE + "/projects/" + aProjectId) //
                 .with(csrf().asHeader()) //
@@ -121,7 +165,7 @@ class MockAeroClient
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions exportProject(long aProjectId) throws Exception
+    ResultActions exportProject(Object aProjectId) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/export.zip") //
                 .with(csrf().asHeader()) //
@@ -141,13 +185,13 @@ class MockAeroClient
                 .param("importPermissions", Boolean.toString(aImportPermissions)));
     }
 
-    ResultActions createAnnotations(long aProjectId, long aDocId, String aUser, String aContent)
+    ResultActions createAnnotations(Object aProjectId, long aDocId, String aUser, String aContent)
         throws Exception
     {
         return createAnnotations(aProjectId, aDocId, aUser, aContent, null);
     }
 
-    ResultActions createAnnotations(long aProjectId, long aDocId, String aUser, String aContent,
+    ResultActions createAnnotations(Object aProjectId, long aDocId, String aUser, String aContent,
             String aState)
         throws Exception
     {
@@ -161,7 +205,7 @@ class MockAeroClient
                 .param("state", aState));
     }
 
-    ResultActions updateAnnotationState(int aProjectId, int aDocId, String aUser, String aState)
+    ResultActions updateAnnotationState(Object aProjectId, int aDocId, String aUser, String aState)
         throws Exception
     {
         var url = API_BASE + "/projects/" + aProjectId + "/documents/" + aDocId + "/annotations/"
@@ -172,7 +216,7 @@ class MockAeroClient
                 .param("state", aState));
     }
 
-    ResultActions listAnnotations(long aProjectId, long aDocId) throws Exception
+    ResultActions listAnnotations(Object aProjectId, long aDocId) throws Exception
     {
         var url = API_BASE + "/projects/" + aProjectId + "/documents/" + aDocId + "/annotations";
         return mvc.perform(get(url) //
@@ -180,7 +224,7 @@ class MockAeroClient
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions importCurations(long aProjectId, long aDocId, String aContent, String aState)
+    ResultActions importCurations(Object aProjectId, long aDocId, String aContent, String aState)
         throws Exception, UnsupportedEncodingException
     {
         var url = API_BASE + "/projects/" + aProjectId + "/documents/" + aDocId + "/curation";
@@ -192,7 +236,7 @@ class MockAeroClient
                 .param("state", aState));
     }
 
-    ResultActions deleteCurations(long aProjectId, long aDocId) throws Exception
+    ResultActions deleteCurations(Object aProjectId, long aDocId) throws Exception
     {
         var url = API_BASE + "/projects/" + aProjectId + "/documents/" + aDocId + "/curation";
         return mvc.perform(delete(url) //
@@ -200,7 +244,8 @@ class MockAeroClient
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions grantProjectRole(long aProjectId, String aUser, String... aRoles) throws Exception
+    ResultActions grantProjectRole(Object aProjectId, String aUser, String... aRoles)
+        throws Exception
     {
         return mvc.perform(post(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
                 .with(csrf().asHeader()) //
@@ -208,28 +253,28 @@ class MockAeroClient
                 .param("roles", aRoles));
     }
 
-    ResultActions grantProjectRoleWithoutRoles(long aProjectId, String aUser) throws Exception
+    ResultActions grantProjectRoleWithoutRoles(Object aProjectId, String aUser) throws Exception
     {
         return mvc.perform(post(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions listPermissionsForUser(long aProjectId, String aUser) throws Exception
+    ResultActions listPermissionsForUser(Object aProjectId, String aUser) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions listPermissionsForProject(long aProjectId) throws Exception
+    ResultActions listPermissionsForProject(Object aProjectId) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/permissions") //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions revokeProjectRole(long aProjectId, String aUser, String... aRoles)
+    ResultActions revokeProjectRole(Object aProjectId, String aUser, String... aRoles)
         throws Exception
     {
         return mvc.perform(delete(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
@@ -238,35 +283,35 @@ class MockAeroClient
                 .param("roles", aRoles));
     }
 
-    ResultActions revokeProjectRoleWithoutRoles(long aProjectId, String aUser) throws Exception
+    ResultActions revokeProjectRoleWithoutRoles(Object aProjectId, String aUser) throws Exception
     {
         return mvc.perform(delete(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions listTasks(long aProjectId) throws Exception
+    ResultActions listTasks(Object aProjectId) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/tasks") //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions cancelTask(long aProjectId, long aTaskId) throws Exception
+    ResultActions cancelTask(Object aProjectId, long aTaskId) throws Exception
     {
         return mvc.perform(delete(API_BASE + "/projects/" + aProjectId + "/tasks/" + aTaskId) //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions listUsers(long aProjectId) throws Exception
+    ResultActions listUsers(Object aProjectId) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/users") //
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)));
     }
 
-    ResultActions createUser(long aProjectId, String aDisplayName) throws Exception
+    ResultActions createUser(Object aProjectId, String aDisplayName) throws Exception
     {
         return mvc.perform(post(API_BASE + "/projects/" + aProjectId + "/users") //
                 .with(csrf().asHeader()) //
@@ -274,7 +319,7 @@ class MockAeroClient
                 .param("name", aDisplayName));
     }
 
-    ResultActions deleteUser(long aProjectId, String aDisplayName) throws Exception
+    ResultActions deleteUser(Object aProjectId, String aDisplayName) throws Exception
     {
         return mvc.perform(delete(API_BASE + "/projects/" + aProjectId + "/users") //
                 .with(csrf().asHeader()) //


### PR DESCRIPTION
**What's in the PR**
- Allow remote API to use project URL slugs in addition to numeric IDs for all project-related endpoints
- Convert all `projectId` path variables across AERO and next controllers from `long` to `String` to accept both forms
- Add `Controller_ImplBase.getProject(String)` with fallback from ID lookup to slug lookup, refactored permission checks into shared `assertCanAccessProject`
- Add `slug` field to `RProject` DTO alongside existing `name` (deprecated); updated `@Schema` descriptions to clarify field semantics
- Update Swagger `@Schema` descriptions for `projectId` parameters across all controllers to document ID/slug duality
- Add regression tests for malformed identifiers, ID-based lookups, slug-based lookups, and permission enforcement via slugs
- Expand `MockAeroClient` test helper to accept `Object` projectId parameter and add `readProject` method
- Document project addressing in remote API admin guide with examples of numeric and slug forms

**How to test manually**
* Try doing calls with the slug instead of the numeric ID

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
