### PR TITLE
#6201 - Deprecate legacy remote API

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/upgrade_notes.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/upgrade_notes.adoc
@@ -24,6 +24,23 @@ NOTE: It is a good idea to back up your installation and data before an upgrade.
       you can actually re-create a working installation by restoring your backup. A backup which cannot be
       successfully restored is worthless.
 
+== INCEpTION 42.0
+
+=== Legacy remote API disabled by default
+
+The legacy WebAnno remote API under `/api/v1` is deprecated and is no longer enabled along with the
+remote API. Previously, `remote-api.enabled=true` enabled both the AERO API (`/api/aero/v1`) and the
+legacy API. Now, the legacy API additionally requires `remote-api.legacy.enabled=true` in the
+`settings.properties` file.
+
+If you have clients accessing `/api/v1`, they will stop working after the upgrade unless you add
+that setting. Mind that the legacy API will be removed entirely in a future version - it is not
+supported by pycaprio and it will not be extended to support project slugs. Hence, it is
+recommended to migrate such clients to the AERO API instead of enabling the legacy API again.
+See <<sect_remote_api>>.
+
+Clients using the AERO API under `/api/aero/v1` are not affected.
+
 == INCEpTION 41.0
 
 === Lucene 10 upgrade

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
@@ -61,6 +61,9 @@ public class RemoteApiAutoConfiguration
             "(${remote-api.enabled:false} || ${webanno.remote-api.enable:false}) && !"
                     + SPEL_IS_ADMIN_ACCOUNT_RECOVERY_MODE;
 
+    static final String LEGACY_REMOTE_API_ENABLED_CONDITION = //
+            "(" + REMOTE_API_ENABLED_CONDITION + ") && ${remote-api.legacy.enabled:false}";
+
     @ConditionalOnExpression(REMOTE_API_ENABLED_CONDITION)
     @Bean
     public AeroProjectController aeroRemoteApiController()
@@ -120,7 +123,12 @@ public class RemoteApiAutoConfiguration
         return new AeroCurationController();
     }
 
-    @ConditionalOnExpression(REMOTE_API_ENABLED_CONDITION)
+    /**
+     * @return the controller of the legacy remote API.
+     * @deprecated The legacy remote API will be removed in a future version.
+     */
+    @Deprecated
+    @ConditionalOnExpression(LEGACY_REMOTE_API_ENABLED_CONDITION)
     @Bean
     public LegacyRemoteApiController legacyRemoteApiController()
     {
@@ -155,7 +163,12 @@ public class RemoteApiAutoConfiguration
                 .build();
     }
 
-    @ConditionalOnExpression(REMOTE_API_ENABLED_CONDITION)
+    /**
+     * @return the OpenAPI group of the legacy remote API.
+     * @deprecated The legacy remote API will be removed in a future version.
+     */
+    @Deprecated
+    @ConditionalOnExpression(LEGACY_REMOTE_API_ENABLED_CONDITION)
     @Bean
     public GroupedOpenApi legacyRemoteApiDocket()
     {
@@ -163,8 +176,11 @@ public class RemoteApiAutoConfiguration
                 .pathsToMatch(LegacyRemoteApiController.API_BASE + "/**") //
                 .addOpenApiCustomizer(openApi -> { //
                     openApi.info(new Info() //
-                            .title("Legacy API") //
-                            .version("1"));
+                            .title("Legacy API (deprecated)") //
+                            .version("1") //
+                            .description(String.join(" ",
+                                    "The legacy WebAnno remote API is deprecated and will be",
+                                    "removed in a future version. Use the AERO API instead.")));
                 }) //
                 .build();
     }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/legacy/LegacyRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/legacy/LegacyRemoteApiController.java
@@ -80,7 +80,12 @@ import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Expose some functions of WebAnno via a RESTful remote API.
+ *
+ * @deprecated The legacy remote API is deprecated and disabled by default. It will be removed in a
+ *             future version. Use the AERO remote API under
+ *             {@link de.tudarmstadt.ukp.inception.remoteapi.Controller_ImplBase#API_BASE} instead.
  */
+@Deprecated
 @ConditionalOnExpression("false") // Auto-configured - avoid package scanning
 @Controller
 @RequestMapping(LegacyRemoteApiController.API_BASE)
@@ -131,7 +136,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "Create a new project")
+    @Operation(summary = "Create a new project", deprecated = true)
     @PostMapping(//
             value = ("/" + PROJECTS), //
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -241,7 +246,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "List all the projects for a given user with their roles")
+    @Operation(summary = "List all the projects for a given user with their roles", deprecated = true)
     @GetMapping(value = ("/" + PROJECTS))
     public ResponseEntity<String> projectList() throws Exception
     {
@@ -287,7 +292,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "Delete a project managed by the given user")
+    @Operation(summary = "Delete a project managed by the given user", deprecated = true)
     @DeleteMapping(value = ("/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}"))
     public ResponseEntity<String> projectDelete(@PathVariable(PARAM_PROJECT_ID) long aProjectId)
         throws Exception
@@ -335,7 +340,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if something went wrong
      */
-    @Operation(summary = "Show source documents in a project managed by the given user")
+    @Operation(summary = "Show source documents in a project managed by the given user", deprecated = true)
     @GetMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS)
     public ResponseEntity<String> sourceDocumentList(
             @PathVariable(PARAM_PROJECT_ID) long aProjectId)
@@ -396,7 +401,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "Delete the source document in project managed by the given user")
+    @Operation(summary = "Delete the source document in project managed by the given user", deprecated = true)
     @DeleteMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}")
     public ResponseEntity<String> sourceDocumentDelete(
@@ -468,7 +473,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "Upload a source document into project managed by the given user")
+    @Operation(summary = "Upload a source document into project managed by the given user", deprecated = true)
     @PostMapping( //
             value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS, //
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -537,7 +542,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "List annotation documents for a source document in a projects managed by the given user")
+    @Operation(summary = "List annotation documents for a source document in a projects managed by the given user", deprecated = true)
     @GetMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}/" + ANNOTATIONS)
     public ResponseEntity<String> annotationDocumentList(
@@ -623,7 +628,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "Download annotation document from a projects managed by the given user")
+    @Operation(summary = "Download annotation document from a projects managed by the given user", deprecated = true)
     @GetMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + DOCUMENTS + "/{"
             + PARAM_DOCUMENT_ID + "}/" + ANNOTATIONS + "/{" + PARAM_USERNAME + "}")
     public void annotationDocumentRead(HttpServletResponse response,
@@ -760,7 +765,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "Download curated document from a projects managed by the given user")
+    @Operation(summary = "Download curated document from a projects managed by the given user", deprecated = true)
     @GetMapping(value = "/" + PROJECTS + "/{" + PARAM_PROJECT_ID + "}/" + CURATION + "/{"
             + PARAM_DOCUMENT_ID + "}")
     public void curationDocumentRead(HttpServletResponse response,

--- a/inception/inception-remote/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-remote/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -19,6 +19,16 @@
       "description": "Enables bulk prediction submission via the remote API task endpoints. Requires remote-api.tasks.enabled=true."
     },
     {
+      "name": "remote-api.legacy.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the deprecated WebAnno-era legacy remote API under /api/v1. Requires remote-api.enabled=true. The legacy API is not supported by pycaprio, does not support project slugs and will be removed in a future version - use the AERO API under /api/aero/v1 instead.",
+      "deprecation": {
+        "level": "warning",
+        "reason": "The legacy remote API is superseded by the AERO API and will be removed in a future version."
+      }
+    },
+    {
       "name": "webanno.remote-api.enable",
       "type": "java.lang.Boolean",
       "defaultValue": false,

--- a/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api.adoc
+++ b/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api.adoc
@@ -155,3 +155,29 @@ and set the realm to `external:inception-client`.
 NOTE: link:https://pycaprio.readthedocs.io/en/latest/[Pycaprio] does currently not support OAuth2
       authentication - only HTTP basic authentication.
 
+== 🪦 Legacy remote API (deprecated)
+
+Next to the AERO remote API, {product-name} still carries the legacy WebAnno remote API which
+uses `<APPLICATION_URL>/api/v1` as the base URL for its operations. This API is **deprecated** and
+will be removed in a future version. It is not supported by
+link:https://pycaprio.readthedocs.io/en/latest/[pycaprio] and it will not be extended to support
+project slugs. If you are still using it, migrate to the AERO API described above.
+
+The legacy API is disabled by default. Enabling the remote API via `remote-api.enabled=true` no
+longer enables it. If you still need it, you have to opt in explicitly by additionally adding
+`remote-api.legacy.enabled=true` to the `settings.properties` file.
+
+.Legacy remote API settings
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| `remote-api.legacy.enabled`
+| Enable the deprecated legacy remote API (requires `remote-api.enabled=true`)
+| `false`
+| `true`
+|===
+

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfigurationConditionsTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfigurationConditionsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config;
+
+import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config.RemoteApiAutoConfiguration.LEGACY_REMOTE_API_ENABLED_CONDITION;
+import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config.RemoteApiAutoConfiguration.REMOTE_API_ENABLED_CONDITION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Ensures that the deprecated legacy remote API is not switched on by merely enabling the remote
+ * API - it requires the additional {@code remote-api.legacy.enabled} opt-in.
+ */
+class RemoteApiAutoConfigurationConditionsTest
+{
+    private static final String AERO_MARKER = "aeroMarker";
+    private static final String LEGACY_MARKER = "legacyMarker";
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfig.class);
+
+    @Test
+    void thatNothingIsEnabledByDefault()
+    {
+        contextRunner.run(ctx -> {
+            assertThat(ctx).doesNotHaveBean(AERO_MARKER);
+            assertThat(ctx).doesNotHaveBean(LEGACY_MARKER);
+        });
+    }
+
+    @Test
+    void thatEnablingRemoteApiDoesNotEnableLegacyApi()
+    {
+        contextRunner.withPropertyValues("remote-api.enabled=true").run(ctx -> {
+            assertThat(ctx).hasBean(AERO_MARKER);
+            assertThat(ctx).doesNotHaveBean(LEGACY_MARKER);
+        });
+    }
+
+    @Test
+    void thatLegacyApiRequiresRemoteApiToBeEnabled()
+    {
+        contextRunner.withPropertyValues("remote-api.legacy.enabled=true").run(ctx -> {
+            assertThat(ctx).doesNotHaveBean(AERO_MARKER);
+            assertThat(ctx).doesNotHaveBean(LEGACY_MARKER);
+        });
+    }
+
+    @Test
+    void thatLegacyApiCanBeEnabledExplicitly()
+    {
+        contextRunner
+                .withPropertyValues("remote-api.enabled=true", "remote-api.legacy.enabled=true")
+                .run(ctx -> {
+                    assertThat(ctx).hasBean(AERO_MARKER);
+                    assertThat(ctx).hasBean(LEGACY_MARKER);
+                });
+    }
+
+    @Test
+    void thatLegacyApiIsAlsoAvailableViaTheLegacyWebAnnoSwitch()
+    {
+        contextRunner.withPropertyValues("webanno.remote-api.enable=true",
+                "remote-api.legacy.enabled=true").run(ctx -> {
+                    assertThat(ctx).hasBean(AERO_MARKER);
+                    assertThat(ctx).hasBean(LEGACY_MARKER);
+                });
+    }
+
+    /**
+     * Mirrors the conditions used by {@link RemoteApiAutoConfiguration} on marker beans so that the
+     * conditions can be exercised without having to provide all the collaborators required by the
+     * actual controllers.
+     */
+    @Configuration(proxyBeanMethods = false)
+    static class TestConfig
+    {
+        @ConditionalOnExpression(REMOTE_API_ENABLED_CONDITION)
+        @Bean(AERO_MARKER)
+        Object aeroMarker()
+        {
+            return new Object();
+        }
+
+        @ConditionalOnExpression(LEGACY_REMOTE_API_ENABLED_CONDITION)
+        @Bean(LEGACY_MARKER)
+        Object legacyMarker()
+        {
+            return new Object();
+        }
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Deprecate legacy WebAnno remote API (`/api/v1`) by making it opt-in behind remote-api.legacy.enabled flag, disabled by default
- Mark `LegacyRemoteApiController` and its endpoints `@Deprecated`, remove from Swagger UI dropdown when disabled
- Update remote API configuration metadata and Spring auto-configuration to gate legacy controller + Swagger group on new flag
- Document legacy API deprecation and new opt-in requirement in admin guide and upgrade notes
- Add `ApplicationContextRunner` test to verify legacy API is not implicitly enabled by remote-api.enabled=true

**How to test manually**
* Check if legacy API is now not available by default

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
