### PR TITLE
#6204 - Documents with a pre-CASMetadata initial CAS cannot be opened, checked, or repaired

### DIFF
--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasMetadataUtils.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasMetadataUtils.java
@@ -81,11 +81,15 @@ public class CasMetadataUtils
             String aUsername)
     {
         // If the type system of the CAS does not yet support CASMetadata, then we do not add it
-        // and wait for the next regular CAS upgrade before we include this data.
-        if (aCas.getTypeSystem().getType(CASMetadata.class.getName()) == null) {
-            throw new IllegalStateException("Annotation file of user [" + aUsername
-                    + "] for document " + aDocument + " in project " + aDocument.getProject() + " "
-                    + "does not support CASMetadata yet");
+        // and wait for the next regular CAS upgrade before we include this data. This can happen
+        // for CASes that were serialized with a type system predating the introduction of
+        // CASMetadata - we must still be able to read those (e.g. for read-only access such as
+        // export or CasDoctor checks) instead of failing outright.
+        if (!supportsCasMetadata(aCas)) {
+            LOG.debug("Annotation file of user [{}] for document {} in project {} does not support "
+                    + "CASMetadata yet - not stamping it. The metadata will be added on the "
+                    + "next regular CAS upgrade.", aUsername, aDocument, aDocument.getProject());
+            return;
         }
 
         var casMetadataType = getType(aCas, CASMetadata.class);
@@ -133,12 +137,24 @@ public class CasMetadataUtils
 
     public static Optional<FeatureStructure> getCasMetadataFS(CAS aCas)
     {
-        return Optional.ofNullable(CasUtil.selectSingle(aCas, getType(aCas, CASMetadata.class)));
+        // An older type system may not declare CASMetadata at all - treat it as absent.
+        var casMetadataType = aCas.getTypeSystem().getType(CASMetadata.class.getName());
+        if (casMetadataType == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(CasUtil.selectSingle(aCas, casMetadataType));
     }
 
     public static long getLastChanged(CAS aCas)
     {
-        var casMetadataType = getType(aCas, CASMetadata.class);
+        // An older type system may not declare CASMetadata at all. We tolerate this here and treat
+        // it as "no timestamp available".
+        var casMetadataType = aCas.getTypeSystem().getType(CASMetadata.class.getName());
+        if (casMetadataType == null) {
+            return UNKNOWN_CAS_TIMESTAMP;
+        }
+
         var feature = casMetadataType.getFeatureByBaseName(CASMetadata._FeatName_lastChangedOnDisk);
         if (feature == null) {
             // An older type system may have a CASMetadata type that does not yet include the
@@ -181,63 +197,55 @@ public class CasMetadataUtils
         return supportsCasMetadata(aCas) && getLastChanged(aCas) == TRANSIENT_CAS_TIMESTAMP;
     }
 
-    public static Optional<String> getUsername(CAS aCas)
+    /**
+     * Reads the given feature from the {@link CASMetadata} instance in the given CAS. Returns an
+     * empty {@link Optional} if the type system does not declare {@link CASMetadata} at all, if the
+     * (older) CASMetadata type does not declare the requested feature, or if the CAS does not
+     * contain exactly one CASMetadata instance.
+     */
+    private static <T> Optional<T> getCasMetadataFeature(CAS aCas, String aFeatureName,
+            Class<T> aClazz)
     {
         try {
-            var fs = CasUtil.selectSingle(aCas, getType(aCas, CASMetadata.class));
-            return Optional.ofNullable(
-                    FSUtil.getFeature(fs, CASMetadata._FeatName_username, String.class));
+            var maybeFs = getCasMetadataFS(aCas);
+            if (maybeFs.isEmpty()) {
+                return Optional.empty();
+            }
+
+            var fs = maybeFs.get();
+            if (fs.getType().getFeatureByBaseName(aFeatureName) == null) {
+                return Optional.empty();
+            }
+
+            return Optional.ofNullable(FSUtil.getFeature(fs, aFeatureName, aClazz));
         }
         catch (IllegalArgumentException e) {
             return Optional.empty();
         }
+    }
+
+    public static Optional<String> getUsername(CAS aCas)
+    {
+        return getCasMetadataFeature(aCas, CASMetadata._FeatName_username, String.class);
     }
 
     public static Optional<Long> getSourceDocumentId(CAS aCas)
     {
-        try {
-            var fs = CasUtil.selectSingle(aCas, getType(aCas, CASMetadata.class));
-            return Optional.ofNullable(
-                    FSUtil.getFeature(fs, CASMetadata._FeatName_sourceDocumentId, Long.class));
-        }
-        catch (IllegalArgumentException e) {
-            return Optional.empty();
-        }
+        return getCasMetadataFeature(aCas, CASMetadata._FeatName_sourceDocumentId, Long.class);
     }
 
     public static Optional<String> getSourceDocumentName(CAS aCas)
     {
-        try {
-            var fs = CasUtil.selectSingle(aCas, getType(aCas, CASMetadata.class));
-            return Optional.ofNullable(
-                    FSUtil.getFeature(fs, CASMetadata._FeatName_sourceDocumentName, String.class));
-        }
-        catch (IllegalArgumentException e) {
-            return Optional.empty();
-        }
+        return getCasMetadataFeature(aCas, CASMetadata._FeatName_sourceDocumentName, String.class);
     }
 
     public static Optional<Long> getProjectId(CAS aCas)
     {
-        try {
-            var fs = CasUtil.selectSingle(aCas, getType(aCas, CASMetadata.class));
-            return Optional
-                    .ofNullable(FSUtil.getFeature(fs, CASMetadata._FeatName_projectId, Long.class));
-        }
-        catch (IllegalArgumentException e) {
-            return Optional.empty();
-        }
+        return getCasMetadataFeature(aCas, CASMetadata._FeatName_projectId, Long.class);
     }
 
     public static Optional<String> getProjectName(CAS aCas)
     {
-        try {
-            var fs = CasUtil.selectSingle(aCas, getType(aCas, CASMetadata.class));
-            return Optional.ofNullable(
-                    FSUtil.getFeature(fs, CASMetadata._FeatName_projectName, String.class));
-        }
-        catch (IllegalArgumentException e) {
-            return Optional.empty();
-        }
+        return getCasMetadataFeature(aCas, CASMetadata._FeatName_projectName, String.class);
     }
 }

--- a/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
+++ b/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
@@ -39,6 +39,7 @@ import static org.apache.uima.fit.util.JCasUtil.select;
 import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 import java.io.File;
@@ -301,6 +302,40 @@ public class CasStorageServiceImplTest
         var cas = makeCas("This is a test");
 
         assertThat(CasMetadataUtils.canMarkTransient(cas)).isTrue();
+    }
+
+    @Test
+    public void testThatCasWithoutCasMetadataTypeCanStillBeAccessed() throws Exception
+    {
+        // A CAS serialized with a type system predating the introduction of CASMetadata does not
+        // declare the type at all. Such a CAS must still be readable - stamping is simply skipped
+        // and the metadata accessors report "absent" instead of failing. Otherwise the CAS could
+        // not even be read for read-only purposes such as export or CasDoctor checks.
+        var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
+        var cas = CasCreationUtils.createCas(tsd, null, null);
+
+        assertThat(CasMetadataUtils.supportsCasMetadata(cas)).isFalse();
+        assertThat(CasMetadataUtils.canMarkTransient(cas)).isFalse();
+
+        var doc = makeSourceDocument(15l, 15l, "test");
+
+        // Stamping must be a no-op rather than throwing
+        assertThatNoException()
+                .isThrownBy(() -> CasMetadataUtils.addOrUpdateCasMetadata(cas, 1234l, doc, "test"));
+
+        // ... and all accessors must report the metadata as absent
+        assertThat(CasMetadataUtils.getLastChanged(cas))
+                .isEqualTo(CasMetadataUtils.UNKNOWN_CAS_TIMESTAMP);
+        assertThat(CasMetadataUtils.isTransientCas(cas)).isFalse();
+        assertThat(CasMetadataUtils.getCasMetadataFS(cas)).isEmpty();
+        assertThat(CasMetadataUtils.getUsername(cas)).isEmpty();
+        assertThat(CasMetadataUtils.getSourceDocumentId(cas)).isEmpty();
+        assertThat(CasMetadataUtils.getSourceDocumentName(cas)).isEmpty();
+        assertThat(CasMetadataUtils.getProjectId(cas)).isEmpty();
+        assertThat(CasMetadataUtils.getProjectName(cas)).isEmpty();
+
+        // Clearing must also tolerate the missing type
+        assertThatNoException().isThrownBy(() -> CasMetadataUtils.clearCasMetadata(cas));
     }
 
     @Test

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/CASMetadataTypeIsPresentCheck.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/CASMetadataTypeIsPresentCheck.java
@@ -17,29 +17,55 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
 
+import static java.util.stream.Collectors.joining;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.uima.UIMAFramework;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.Type;
+import org.apache.uima.resource.metadata.TypeDescription;
+import org.apache.uima.util.XMLInputSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
 /**
- * Checks if the type {@link CASMetadata} is defined in the type system of this CAS. If this is not
- * the case, then the application may not be able to detect concurrent modifications.
+ * Checks if the type {@link CASMetadata} is defined in the type system of this CAS and whether its
+ * definition is up-to-date. If the type is missing or outdated, then the application may not be
+ * able to detect concurrent modifications.
  */
 public class CASMetadataTypeIsPresentCheck
     implements Check
 {
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String INTERNAL_TYPE_SYSTEM = //
+            "/de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal.xml";
+
     @Override
     public boolean check(SourceDocument aDocument, String aDataOwner, CAS aCas,
             List<LogMessage> aMessages)
     {
-        if (aCas.getTypeSystem().getType(CASMetadata._TypeName) == null) {
-            aMessages.add(LogMessage.info(this, "CAS needs upgrade to support CASMetadata which is "
+        var casMetadataType = aCas.getTypeSystem().getType(CASMetadata._TypeName);
+
+        if (casMetadataType == null) {
+            aMessages.add(LogMessage.warn(this, "CAS needs upgrade to support CASMetadata which is "
                     + "required to detect concurrent modifications to CAS files."));
             return true;
+        }
+
+        var missingFeatures = getMissingFeatures(casMetadataType);
+        if (!missingFeatures.isEmpty()) {
+            aMessages.add(LogMessage.warn(this,
+                    "CAS needs upgrade to bring CASMetadata up-to-date. The following features are "
+                            + "missing: [%s].",
+                    missingFeatures.stream().collect(joining(", "))));
         }
 
         if (aCas.select(CASMetadata.class).isEmpty()) {
@@ -49,5 +75,69 @@ public class CASMetadataTypeIsPresentCheck
 
         // This is an informative check - not critical, so we always pass it.
         return true;
+    }
+
+    /**
+     * @return the names of the features which the current {@link CASMetadata} definition declares
+     *         but which are absent from the CASMetadata type in the given CAS. An older CAS may
+     *         carry a CASMetadata type that predates the addition of some features - such a CAS
+     *         silently loses the functionality backed by those features (e.g. concurrent
+     *         modification detection, which requires {@code lastChangedOnDisk}).
+     */
+    private List<String> getMissingFeatures(Type aCasMetadataType)
+    {
+        var missingFeatures = new ArrayList<String>();
+
+        for (var expectedFeature : getExpectedFeatures()) {
+            if (aCasMetadataType.getFeatureByBaseName(expectedFeature) == null) {
+                missingFeatures.add(expectedFeature);
+            }
+        }
+
+        return missingFeatures;
+    }
+
+    /**
+     * @return the feature names declared by the current {@link CASMetadata} type definition. These
+     *         are obtained from the internal type system description rather than being hard-coded
+     *         so that this check does not go stale when features are added to CASMetadata.
+     */
+    private List<String> getExpectedFeatures()
+    {
+        try (var is = getClass().getResourceAsStream(INTERNAL_TYPE_SYSTEM)) {
+            if (is == null) {
+                LOG.warn("Unable to locate the internal type system at [{}] - cannot determine the "
+                        + "expected CASMetadata features", INTERNAL_TYPE_SYSTEM);
+                return List.of();
+            }
+
+            var tsd = UIMAFramework.getXMLParser()
+                    .parseTypeSystemDescription(new XMLInputSource(is, null));
+
+            var typeDescription = tsd.getType(CASMetadata._TypeName);
+            if (typeDescription == null) {
+                LOG.warn("Internal type system does not declare [{}] - cannot determine the "
+                        + "expected CASMetadata features", CASMetadata._TypeName);
+                return List.of();
+            }
+
+            return featureNames(typeDescription);
+        }
+        catch (Exception e) {
+            // If we cannot load the internal type system, we simply do not report missing features
+            // instead of failing the entire check.
+            LOG.warn("Unable to determine the expected CASMetadata features", e);
+            return List.of();
+        }
+    }
+
+    private List<String> featureNames(TypeDescription aTypeDescription)
+    {
+        var features = aTypeDescription.getFeatures();
+        if (features == null) {
+            return List.of();
+        }
+
+        return List.of(features).stream().map(f -> f.getName()).toList();
     }
 }

--- a/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/CASMetadataTypeIsPresentCheckTest.java
+++ b/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/CASMetadataTypeIsPresentCheckTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.support.logging.LogLevel;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+class CASMetadataTypeIsPresentCheckTest
+{
+    CASMetadataTypeIsPresentCheck sut;
+    SourceDocument document;
+    String dataOwner;
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        sut = new CASMetadataTypeIsPresentCheck();
+        document = SourceDocument.builder().build();
+    }
+
+    @Test
+    void thatMissingCasMetadataTypeIsReported() throws Exception
+    {
+        // A CAS serialized with a type system predating the introduction of CASMetadata does not
+        // declare the type at all.
+        var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
+        var cas = CasCreationUtils.createCas(tsd, null, null);
+
+        var messages = new ArrayList<LogMessage>();
+
+        var result = sut.check(document, dataOwner, cas, messages);
+
+        assertThat(result).isTrue();
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).getLevel()).isEqualTo(LogLevel.WARN);
+        assertThat(messages.get(0).getMessage()).contains("needs upgrade to support CASMetadata");
+    }
+
+    @Test
+    void thatOutdatedCasMetadataTypeIsReported() throws Exception
+    {
+        // An older type system may declare a CASMetadata type that predates the addition of some
+        // features - most importantly lastChangedOnDisk, without which concurrent modification
+        // detection silently stops working.
+        var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
+        var type = tsd.addType(CASMetadata._TypeName, "", CAS.TYPE_NAME_ANNOTATION);
+        type.addFeature(CASMetadata._FeatName_username, "", CAS.TYPE_NAME_STRING);
+
+        var cas = CasCreationUtils.createCas(tsd, null, null);
+        var casMetadataType = cas.getTypeSystem().getType(CASMetadata._TypeName);
+        cas.addFsToIndexes(cas.createAnnotation(casMetadataType, 0, 0));
+
+        var messages = new ArrayList<LogMessage>();
+
+        var result = sut.check(document, dataOwner, cas, messages);
+
+        assertThat(result).isTrue();
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).getLevel()).isEqualTo(LogLevel.WARN);
+        assertThat(messages.get(0).getMessage()) //
+                .contains("needs upgrade to bring CASMetadata up-to-date") //
+                .contains(CASMetadata._FeatName_lastChangedOnDisk) //
+                .contains(CASMetadata._FeatName_projectId) //
+                .doesNotContain("[" + CASMetadata._FeatName_username + "]");
+    }
+
+    @Test
+    void thatMissingCasMetadataInstanceIsReported() throws Exception
+    {
+        // The type is up-to-date, but the CAS carries no CASMetadata instance.
+        var cas = makeCasWithCurrentTypeSystem();
+
+        var messages = new ArrayList<LogMessage>();
+
+        var result = sut.check(document, dataOwner, cas, messages);
+
+        assertThat(result).isTrue();
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).getLevel()).isEqualTo(LogLevel.WARN);
+        assertThat(messages.get(0).getMessage()).contains("contains no CASMetadata");
+    }
+
+    @Test
+    void thatUpToDateCasMetadataIsNotReported() throws Exception
+    {
+        var cas = makeCasWithCurrentTypeSystem();
+        var casMetadataType = cas.getTypeSystem().getType(CASMetadata._TypeName);
+        cas.addFsToIndexes(cas.createAnnotation(casMetadataType, 0, 0));
+
+        var messages = new ArrayList<LogMessage>();
+
+        var result = sut.check(document, dataOwner, cas, messages);
+
+        assertThat(result).isTrue();
+        assertThat(messages).isEmpty();
+    }
+
+    private CAS makeCasWithCurrentTypeSystem() throws Exception
+    {
+        var tsd = createTypeSystemDescription(
+                "de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal");
+        return CasCreationUtils.createCas(tsd, null, null);
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Allow CASes with legacy or missing CASMetadata type to be read without throwing; treat absent metadata as unavailable rather than fatal
- Extend CASMetadataUtils getters to gracefully handle CAS type systems that lack CASMetadata entirely or have outdated feature sets
- Add regression test verifying legacy CASes without CASMetadata type can be deserialized and stamped without error
- Promote CASMetadataTypeIsPresentCheck from reporting missing type as INFO to WARN; add detection and reporting of outdated (stale) CASMetadata with missing features
- Refactor CASMetadataTypeIsPresentCheck to load type system descriptor via UIMAFramework.getXMLParser() instead of createTypeSystemDescription, eliminating import-resolution indirection
- Add comprehensive test suite for CASMetadataTypeIsPresentCheck covering missing type, outdated type, missing instance, and current-up-to-date cases

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
