### PR TITLE
#6200 - Let users see their own roles in a project via remote API

### DIFF
--- a/inception/inception-remote/pom.xml
+++ b/inception/inception-remote/pom.xml
@@ -259,7 +259,8 @@
    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-    </dependency>    <dependency>
+    </dependency>    
+    <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
     </dependency>
@@ -457,6 +458,16 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroAnnotationController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroAnnotationController.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.INFO;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.ANNOTATION_STATE_COMPLETE;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.ANNOTATION_STATE_IN_PROGRESS;
@@ -24,11 +25,11 @@ import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtil
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.ANNOTATION_STATE_NEW;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.annotationDocumentStateToString;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.parseAnnotationDocumentState;
+import static java.lang.invoke.MethodHandles.lookup;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -73,7 +74,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class AeroAnnotationController
     extends Controller_ImplBase
 {
-    private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private final static Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
 
     @Operation(summary = "List annotations of a document in a project")
     @GetMapping( //
@@ -95,7 +96,7 @@ public class AeroAnnotationController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var doc = getDocument(project, aDocumentId);
 
@@ -160,11 +161,11 @@ public class AeroAnnotationController
         throws Exception
     {
         var annotator = getUser(aAnnotatorId);
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
         var document = getDocument(project, aDocumentId);
         var anno = getAnnotation(document, aAnnotatorId, true);
 
-        var annotationCas = createCompatibleCas(aProjectId, aDocumentId, aFile, aFormat);
+        var annotationCas = createCompatibleCas(project, aDocumentId, aFile, aFormat);
 
         // If they are compatible, then we can store the new annotations
         documentService.writeAnnotationCas(annotationCas, document, annotator);
@@ -228,7 +229,10 @@ public class AeroAnnotationController
             Optional<String> aFormat)
         throws Exception
     {
-        return readAnnotation(aProjectId, aDocumentId, aAnnotatorId, Mode.ANNOTATION, aFormat);
+        // Get project (this also ensures that it exists and that the current user can access it
+        var project = getProject(aProjectId, MANAGER);
+
+        return readAnnotation(project, aDocumentId, aAnnotatorId, Mode.ANNOTATION, aFormat);
     }
 
     @Operation(summary = "Delete a user's annotations of one document from a project")
@@ -256,7 +260,7 @@ public class AeroAnnotationController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var doc = getDocument(project, aDocumentId);
         var anno = getAnnotation(doc, aAnnotatorId, false);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroCurationController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroCurationController.java
@@ -17,8 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.INFO;
 import static de.tudarmstadt.ukp.inception.remoteapi.SourceDocumentStateUtils.parseSourceDocumentState;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
@@ -52,7 +54,6 @@ import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RResponse;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config.RemoteApiAutoConfiguration;
 import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentService;
 import de.tudarmstadt.ukp.inception.remoteapi.Controller_ImplBase;
-import de.tudarmstadt.ukp.inception.support.WebAnnoConst;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -124,10 +125,10 @@ public class AeroCurationController
             UriComponentsBuilder aUcb)
         throws Exception
     {
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
         var document = getDocument(project, aDocumentId);
 
-        var annotationCas = createCompatibleCas(aProjectId, aDocumentId, aFile, aFormat);
+        var annotationCas = createCompatibleCas(project, aDocumentId, aFile, aFormat);
 
         // If they are compatible, then we can store the new annotations
         curationService.writeCurationCas(annotationCas, document, false);
@@ -159,8 +160,7 @@ public class AeroCurationController
             documentService.createSourceDocument(document);
         }
 
-        var response = new RResponse<>(
-                new RAnnotation(WebAnnoConst.CURATION_USER, resultState, new Date()));
+        var response = new RResponse<>(new RAnnotation(CURATION_USER, resultState, new Date()));
         return ResponseEntity.created(
                 aUcb.path(API_BASE + "/" + PROJECTS + "/{pid}/" + DOCUMENTS + "/{did}/" + CURATION)
                         .buildAndExpand(project.getId(), document.getId()).toUri())
@@ -199,8 +199,8 @@ public class AeroCurationController
             Optional<String> aFormat)
         throws Exception
     {
-        return readAnnotation(aProjectId, aDocumentId, WebAnnoConst.CURATION_USER, Mode.CURATION,
-                aFormat);
+        var project = getProject(aProjectId, MANAGER);
+        return readAnnotation(project, aDocumentId, CURATION_USER, Mode.CURATION, aFormat);
     }
 
     @Operation(summary = "Delete a user's annotations of one document from a project")
@@ -223,7 +223,7 @@ public class AeroCurationController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var doc = getDocument(project, aDocumentId);
         curationService.deleteCurationCas(doc);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroDocumentController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroDocumentController.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.INFO;
 import static de.tudarmstadt.ukp.inception.remoteapi.SourceDocumentStateUtils.DOCUMENT_STATE_ANNOTATION_COMPLETE;
 import static de.tudarmstadt.ukp.inception.remoteapi.SourceDocumentStateUtils.DOCUMENT_STATE_ANNOTATION_IN_PROGRESS;
@@ -86,7 +87,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class AeroDocumentController
     extends Controller_ImplBase
 {
-    private final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @Autowired DocumentStorageService documentStorageService;
 
@@ -103,7 +104,7 @@ public class AeroDocumentController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var documents = documentService.listSourceDocuments(project);
 
@@ -158,7 +159,7 @@ public class AeroDocumentController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         // Check if the format is supported
         if (!importExportService.getReadableFormatById(aFormat).isPresent()) {
@@ -249,7 +250,7 @@ public class AeroDocumentController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var doc = getDocument(project, aDocumentId);
 
@@ -338,7 +339,7 @@ public class AeroDocumentController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var doc = getDocument(project, aDocumentId);
         documentService.removeSourceDocument(doc);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroKnowledgeBaseController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroKnowledgeBaseController.java
@@ -84,15 +84,7 @@ public class AeroKnowledgeBaseController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var sessionOwner = getSessionOwner();
-
-        // Check for the access
-        assertPermission("User [" + sessionOwner.getUsername()
-                + "] is not allowed to access knowledge bases in project [" + aProjectId + "]",
-                projectService.hasRole(sessionOwner, project, MANAGER)
-                        || userRepository.isAdministrator(sessionOwner));
+        var project = getProject(aProjectId, MANAGER);
 
         var kbs = knowledgeBaseService.getEnabledKnowledgeBases(project);
 
@@ -127,15 +119,7 @@ public class AeroKnowledgeBaseController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var sessionOwner = getSessionOwner();
-
-        // Check for the access
-        assertPermission("User [" + sessionOwner.getUsername()
-                + "] is not allowed to access knowledge bases in project [" + aProjectId + "]",
-                projectService.hasRole(sessionOwner, project, MANAGER)
-                        || userRepository.isAdministrator(sessionOwner));
+        var project = getProject(aProjectId, MANAGER);
 
         var maybeKb = knowledgeBaseService.getKnowledgeBaseById(project, aKbId);
         if (!maybeKb.map(KnowledgeBase::isEnabled).orElse(false)) {
@@ -178,15 +162,7 @@ public class AeroKnowledgeBaseController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var sessionOwner = getSessionOwner();
-
-        // Check for the access
-        assertPermission("User [" + sessionOwner.getUsername()
-                + "] is not allowed to access knowledge bases in project [" + aProjectId + "]",
-                projectService.hasRole(sessionOwner, project, MANAGER)
-                        || userRepository.isAdministrator(sessionOwner));
+        var project = getProject(aProjectId, MANAGER);
 
         var bindingNames = new HashSet<String>();
         var combined = new ArrayList<BindingSet>();

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectController.java
@@ -64,11 +64,13 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.model.ScriptDirection;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.exception.IllegalNameException;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.exception.ObjectExistsException;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.exception.ObjectNotFoundException;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.exception.UnsupportedFormatException;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RProject;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RResponse;
@@ -94,26 +96,73 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class AeroProjectController
     extends Controller_ImplBase
 {
-    private final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @Autowired ProjectExportService exportService;
 
-    @Operation(summary = "List the projects accessible by the authenticated user")
+    @Operation(summary = "List the projects manageable by the authenticated user")
     @GetMapping(value = ("/" + PROJECTS), produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<RResponse<List<RProject>>> list() throws Exception
     {
         // Get current user - this will throw an exception if the current user does not exit
         var sessionOwner = getSessionOwner();
 
-        // Get projects with permission
-        var accessibleProjects = projectService.listAccessibleProjects(sessionOwner);
+        // Get projects with permission - along with the roles the session owner holds in them so
+        // that callers do not have to query the permissions of each project separately. Only
+        // projects which the session owner manages are reported - consistent with the other
+        // endpoints of this API, all of which require the manager role. Administrators see all
+        // projects, even those in which they hold no roles.
+        var isAdministrator = userRepository.isAdministrator(sessionOwner);
+        var accessibleProjects = projectService.listAccessibleProjectsWithPermissions(sessionOwner);
 
         // Collect all the projects
         var projectList = new ArrayList<RProject>();
-        for (var project : accessibleProjects) {
-            projectList.add(new RProject(project));
+        for (var entry : accessibleProjects.entrySet()) {
+            if (isAdministrator || entry.getValue().contains(MANAGER)) {
+                projectList.add(RProject.builder() //
+                        .withProject(entry.getKey()) //
+                        .withRoles(entry.getValue()) //
+                        .build());
+            }
         }
         return ResponseEntity.ok(new RResponse<>(projectList));
+    }
+
+    /**
+     * Renders the given project along with the roles which the session owner holds in it.
+     */
+    private RProject toRProject(Project aProject) throws ObjectNotFoundException
+    {
+        return toRProject(aProject, getSessionOwner().getUsername());
+    }
+
+    /**
+     * Renders the given project along with the roles which the given user holds in it. When a
+     * project is created or imported on behalf of another user, the roles of that other user are
+     * reported - the session owner (typically an administrator) does not receive any roles in that
+     * case, so reporting their roles would always yield an empty list and would not answer the
+     * question whether the roles were successfully assigned.
+     *
+     * @param aSubjectUser
+     *            the user whose roles to report or {@code null} if there is no such user, in which
+     *            case no roles are reported.
+     */
+    private RProject toRProject(Project aProject, String aSubjectUser)
+    {
+        if (aSubjectUser == null) {
+            return RProject.builder() //
+                    .withProject(aProject) //
+                    .build();
+        }
+
+        var roles = projectService.listProjectPermissionLevel(aSubjectUser, aProject).stream() //
+                .map(ProjectPermission::getLevel) //
+                .toList();
+
+        return RProject.builder() //
+                .withProject(aProject) //
+                .withRoles(roles) //
+                .build();
     }
 
     @Operation(summary = "Create a new project")
@@ -212,7 +261,9 @@ public class AeroProjectController
         String owner = aCreator.isPresent() ? aCreator.get() : sessionOwner.getUsername();
         projectService.assignRole(project, owner, MANAGER, CURATOR, ANNOTATOR);
 
-        RResponse<RProject> response = new RResponse<>(new RProject(project));
+        // Report the roles of the project owner - when an administrator creates a project on
+        // behalf of somebody else, it is the owner and not the administrator who receives roles.
+        RResponse<RProject> response = new RResponse<>(toRProject(project, owner));
         return ResponseEntity.created(aUcb.path(API_BASE + "/" + PROJECTS + "/{id}")
                 .buildAndExpand(project.getId()).toUri()).body(response);
     }
@@ -230,9 +281,9 @@ public class AeroProjectController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
-        return ResponseEntity.ok(new RResponse<>(new RProject(project)));
+        return ResponseEntity.ok(new RResponse<>(toRProject(project)));
     }
 
     @Operation(summary = "Delete an existing project")
@@ -248,7 +299,7 @@ public class AeroProjectController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         projectService.removeProject(project);
 
@@ -344,7 +395,11 @@ public class AeroProjectController
             tempFile.delete();
         }
 
-        return ResponseEntity.ok(new RResponse<>(new RProject(importedProject)));
+        // Report the roles of the user who was set up as the project manager during the import. If
+        // the permissions were imported from the archive, then nobody was set up as a manager and
+        // we do not report any roles.
+        return ResponseEntity.ok(new RResponse<>(
+                toRProject(importedProject, manager != null ? manager.getUsername() : null)));
     }
 
     @Operation(summary = "Export a project to a ZIP file")
@@ -377,7 +432,7 @@ public class AeroProjectController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         // Check if the format is supported
         if (aFormat.isPresent()) {

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RProject.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RProject.java
@@ -17,54 +17,158 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model;
 
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toCollection;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public class RProject
-{
-    @Schema(description = """
-            Numeric project identifier. Can be used in place of the slug when addressing the
-            project in API paths.
-            """)
-    public long id;
+/**
+ * @param id
+ *            numeric project identifier.
+ * @param name
+ *            deprecated - carries the project slug. Use {@code slug} instead.
+ * @param slug
+ *            URL slug of the project.
+ * @param title
+ *            human-readable name of the project.
+ * @param roles
+ *            roles held in this project.
+ */
+public record RProject( //
+        @Schema(description = """
+                Numeric project identifier. Can be used in place of the slug when addressing the
+                project in API paths.
+                """) //
+        long id, //
 
+        @Deprecated //
+        @Schema(description = """
+                URL slug of the project. Deprecated - use `slug` instead. Note that this field
+                carries the slug and not the human-readable project name which is available as
+                `title`.
+                """) //
+        String name, //
+
+        @Schema(description = """
+                URL slug of the project. Can be used in place of the numeric ID when addressing
+                the project in API paths.
+                """) //
+        String slug, //
+
+        @Schema(description = """
+                Human-readable name of the project.
+                """) //
+        String title, //
+
+        @Schema(description = """
+                Roles held in this project (non-AERO). When listing or reading projects, these are the
+                roles of the authenticated user - never those of any other user. When creating or
+                importing a project, these are instead the roles of the user the project was created
+                for, since an administrator acting on behalf of somebody else does not receive any
+                roles. The list may be empty, e.g. for an administrator who can access a project
+                without holding any explicitly assigned roles in it.
+                """, //
+                allowableValues = {
+                        "ANNOTATOR", "CURATOR", "MANAGER" }, //
+                extensions = @Extension( //
+                        properties = @ExtensionProperty(name = "x-aero", value = "false"))) //
+        List<String> roles) {
     /**
-     * @deprecated Use {@link #slug} instead. This field carries the project slug, not the
-     *             human-readable project name - the latter is available as {@link #title}.
+     * Sorts by the natural order of the enum so that the roles are reported in a stable order
+     * irrespective of how they were assigned.
      */
-    @Deprecated
-    @Schema(description = """
-            URL slug of the project. Deprecated - use `slug` instead. Note that this field
-            carries the slug and not the human-readable project name which is available as
-            `title`.
-            """)
-    public String name;
-
-    @Schema(description = """
-            URL slug of the project. Can be used in place of the numeric ID when addressing
-            the project in API paths.
-            """)
-    public String slug;
-
-    @Schema(description = """
-            Human-readable name of the project.
-            """)
-    public String title;
-
-    public RProject(Project aProject)
+    private static List<String> toRoleNames(Collection<PermissionLevel> aRoles)
     {
-        id = aProject.getId();
-        name = aProject.getSlug();
-        slug = aProject.getSlug();
-        title = aProject.getName();
+        if (aRoles == null) {
+            return emptyList();
+        }
+
+        return aRoles.stream() //
+                .sorted() //
+                .map(PermissionLevel::name) //
+                .collect(toCollection(ArrayList::new));
     }
 
-    public RProject(long aId, String aTitle, String aSlug)
+    public static Builder builder()
     {
-        super();
-        id = aId;
-        name = aSlug;
-        slug = aSlug;
-        title = aTitle;
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private long id;
+        private String name;
+        private String slug;
+        private String title;
+        private List<String> roles = new ArrayList<>();
+
+        private Builder()
+        {
+        }
+
+        public Builder withProject(Project aProject)
+        {
+            id = aProject.getId();
+            name = aProject.getSlug();
+            slug = aProject.getSlug();
+            title = aProject.getName();
+            return this;
+        }
+
+        public Builder withId(long aId)
+        {
+            id = aId;
+            return this;
+        }
+
+        public Builder withName(String aName)
+        {
+            name = aName;
+            return this;
+        }
+
+        public Builder withSlug(String aSlug)
+        {
+            slug = aSlug;
+            return this;
+        }
+
+        public Builder withTitle(String aTitle)
+        {
+            title = aTitle;
+            return this;
+        }
+
+        public Builder withRoles(List<String> aRoles)
+        {
+            roles.clear();
+            if (aRoles != null) {
+                roles.addAll(aRoles);
+            }
+
+            return this;
+        }
+
+        /**
+         * Set the roles from the permission levels held in the project. The roles are reported in a
+         * stable order irrespective of the order in which they were assigned.
+         */
+        public Builder withRoles(Collection<PermissionLevel> aRoles)
+        {
+            return withRoles(toRoleNames(aRoles));
+        }
+
+        public RProject build()
+        {
+            return new RProject(id, name, slug, title, roles);
+        }
     }
 }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/legacy/LegacyRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/legacy/LegacyRemoteApiController.java
@@ -246,7 +246,7 @@ public class LegacyRemoteApiController
      * @throws Exception
      *             if there was an error.
      */
-    @Operation(summary = "List all the projects for a given user with their roles", deprecated = true)
+    @Operation(summary = "List all the projects managed by a given user with their roles", deprecated = true)
     @GetMapping(value = ("/" + PROJECTS))
     public ResponseEntity<String> projectList() throws Exception
     {
@@ -257,8 +257,10 @@ public class LegacyRemoteApiController
             return ResponseEntity.badRequest().body("User [" + username + "] not found.");
         }
 
-        // Get projects with permission
-        List<Project> accessibleProjects = projectRepository.listAccessibleProjects(user);
+        // Get the projects which the user manages - the remote API requires the manager role
+        // throughout, so projects in which the user is merely an annotator or curator are not
+        // reported here. Administrators see all projects.
+        List<Project> accessibleProjects = projectRepository.listManageableProjects(user);
 
         // Add permissions for each project into JSON array and store in JSON object
         JSONObject returnJSONObj = new JSONObject();

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/Controller_ImplBase.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/Controller_ImplBase.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.remoteapi;
 
-import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.ERROR;
 import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.forceOverwriteSofa;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectSentences;
@@ -60,6 +59,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -176,18 +176,23 @@ public abstract class Controller_ImplBase
         return user;
     }
 
-    protected Project getProject(long aProjectId)
-        throws ObjectNotFoundException, AccessForbiddenException
+    /**
+     * Look up a project by its numeric ID or by its URL slug without performing any access check.
+     */
+    private Project lookupProject(String aProjectId) throws ObjectNotFoundException
     {
-        Project project;
+        var projectId = toProjectId(aProjectId);
+
         try {
-            project = projectService.getProject(aProjectId);
+            if (projectId != null) {
+                return projectService.getProject(projectId.longValue());
+            }
+
+            return projectService.getProjectBySlug(aProjectId);
         }
         catch (NoResultException e) {
             throw new ObjectNotFoundException("Project [" + aProjectId + "] not found.");
         }
-
-        return assertCanAccessProject(project, String.valueOf(aProjectId));
     }
 
     /**
@@ -203,23 +208,11 @@ public abstract class Controller_ImplBase
      * @throws AccessForbiddenException
      *             if the session owner may not access the project.
      */
-    protected Project getProject(String aProjectId)
+    protected Project getProject(String aProjectId, PermissionLevel aRole,
+            PermissionLevel... aMoreRoles)
         throws ObjectNotFoundException, AccessForbiddenException
     {
-        var projectId = toProjectId(aProjectId);
-        if (projectId != null) {
-            return getProject(projectId.longValue());
-        }
-
-        Project project;
-        try {
-            project = projectService.getProjectBySlug(aProjectId);
-        }
-        catch (NoResultException e) {
-            throw new ObjectNotFoundException("Project [" + aProjectId + "] not found.");
-        }
-
-        return assertCanAccessProject(project, aProjectId);
+        return assertCanAccessProject(lookupProject(aProjectId), aProjectId, aRole, aMoreRoles);
     }
 
     /**
@@ -236,17 +229,19 @@ public abstract class Controller_ImplBase
         }
     }
 
-    private Project assertCanAccessProject(Project aProject, String aProjectId)
+    private Project assertCanAccessProject(Project aProject, String aProjectId,
+            PermissionLevel aRole, PermissionLevel... aMoreRoles)
         throws ObjectNotFoundException, AccessForbiddenException
     {
+
         // Get current user - this will throw an exception if the current user does not exit
         var sessionOwner = getSessionOwner();
 
         // Check for the access
         assertPermission(
-                "User [" + sessionOwner.getUsername() + "] is not allowed to access project ["
+                "User [" + sessionOwner.getUsername() + "] has insufficient privileges on project ["
                         + aProjectId + "]",
-                projectService.hasRole(sessionOwner, aProject, MANAGER)
+                projectService.hasRole(sessionOwner, aProject, aRole, aMoreRoles)
                         || userRepository.isAdministrator(sessionOwner));
 
         return aProject;
@@ -291,12 +286,11 @@ public abstract class Controller_ImplBase
         }
     }
 
-    protected CAS createCompatibleCas(String aProjectId, long aDocumentId, MultipartFile aFile,
+    protected CAS createCompatibleCas(Project aProject, long aDocumentId, MultipartFile aFile,
             Optional<String> aFormatId)
         throws RemoteApiException, ClassNotFoundException, IOException, UIMAException
     {
-        var project = getProject(aProjectId);
-        var document = getDocument(project, aDocumentId);
+        var document = getDocument(aProject, aDocumentId);
 
         // Check if the format is supported
         var format = aFormatId.orElse(FORMAT_DEFAULT);
@@ -369,14 +363,11 @@ public abstract class Controller_ImplBase
         return annotationCas;
     }
 
-    protected ResponseEntity<byte[]> readAnnotation(String aProjectId, long aDocumentId,
+    protected ResponseEntity<byte[]> readAnnotation(Project aProject, long aDocumentId,
             String aAnnotatorId, Mode aMode, Optional<String> aFormat)
         throws RemoteApiException, ClassNotFoundException, IOException, UIMAException
     {
-        // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var doc = getDocument(project, aDocumentId);
+        var doc = getDocument(aProject, aDocumentId);
 
         // Check format
         String formatId;

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/AnnotationController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/AnnotationController.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.remoteapi.next;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.INFO;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.ANNOTATION_STATE_COMPLETE;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.ANNOTATION_STATE_IN_PROGRESS;
@@ -98,7 +99,7 @@ public class AnnotationController
             String aState)
         throws Exception
     {
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
         var document = getDocument(project, aDocumentId);
 
         var anno = getAnnotation(document, aAnnotatorId, false);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/PermissionController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/PermissionController.java
@@ -74,16 +74,7 @@ public class PermissionController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var sessionOwner = getSessionOwner();
-
-        // Check for the access
-        assertPermission(
-                "User [" + sessionOwner.getUsername()
-                        + "] is not allowed to list project permissions",
-                projectService.hasRole(sessionOwner, project, MANAGER)
-                        || userRepository.isAdministrator(sessionOwner));
+        var project = getProject(aProjectId, MANAGER);
 
         var permissions = projectService.listProjectPermissions(project).stream() //
                 .map(RPermission::new) //
@@ -112,16 +103,7 @@ public class PermissionController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var sessionOwner = getSessionOwner();
-
-        // Check for the access
-        assertPermission(
-                "User [" + sessionOwner.getUsername()
-                        + "] is not allowed to list project permissions",
-                projectService.hasRole(sessionOwner, project, MANAGER)
-                        || userRepository.isAdministrator(sessionOwner));
+        var project = getProject(aProjectId, MANAGER);
 
         var subjectUser = getUser(aSubjectUser);
 
@@ -158,16 +140,7 @@ public class PermissionController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var sessionOwner = getSessionOwner();
-
-        // Check for the access
-        assertPermission(
-                "User [" + sessionOwner.getUsername()
-                        + "] is not allowed to manage project permissions",
-                projectService.hasRole(sessionOwner, project, MANAGER)
-                        || userRepository.isAdministrator(sessionOwner));
+        var project = getProject(aProjectId, MANAGER);
 
         var subjectUser = getUser(aSubjectUser);
 
@@ -211,16 +184,7 @@ public class PermissionController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
-
-        var sessionOwner = getSessionOwner();
-
-        // Check for the access
-        assertPermission(
-                "User [" + sessionOwner.getUsername()
-                        + "] is not allowed to manage project permissions",
-                projectService.hasRole(sessionOwner, project, MANAGER)
-                        || userRepository.isAdministrator(sessionOwner));
+        var project = getProject(aProjectId, MANAGER);
 
         var subjectUser = getUser(aSubjectUser);
 

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskBulkPredictionController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskBulkPredictionController.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.remoteapi.next;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.TrainingCapability.TRAINING_REQUIRED;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.ANNOTATION_STATE_COMPLETE;
 import static de.tudarmstadt.ukp.inception.remoteapi.AnnotationDocumentStateUtils.ANNOTATION_STATE_IN_PROGRESS;
@@ -132,7 +133,7 @@ public class TaskBulkPredictionController
             boolean aFinishDocumentsWithoutRecommendations)
         throws Exception
     {
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
         var sessionOwner = getSessionOwner();
 
         taskAccess.assertCanManageTasks(sessionOwner, project);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/TaskController.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.remoteapi.next;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -71,7 +72,7 @@ public class TaskController
             String aProjectId)
         throws Exception
     {
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
         var sessionOwner = getSessionOwner();
 
         taskAccess.assertCanManageTasks(sessionOwner, project);
@@ -103,7 +104,7 @@ public class TaskController
             long aTaskId)
         throws Exception
     {
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
         var sessionOwner = getSessionOwner();
 
         taskAccess.assertCanManageTasks(sessionOwner, project);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/UserController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/UserController.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.remoteapi.next;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.ERROR;
 import static java.util.stream.Collectors.toList;
 import static org.springframework.http.HttpStatus.CONFLICT;
@@ -81,7 +82,7 @@ public class UserController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var sessionOwner = getSessionOwner();
 
@@ -114,7 +115,7 @@ public class UserController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var sessionOwner = getSessionOwner();
 
@@ -151,7 +152,7 @@ public class UserController
         throws Exception
     {
         // Get project (this also ensures that it exists and that the current user can access it
-        var project = getProject(aProjectId);
+        var project = getProject(aProjectId, MANAGER);
 
         var sessionOwner = getSessionOwner();
 

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroProjectControllerTest.java
@@ -19,7 +19,10 @@ package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero;
 
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_REMOTE;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -101,19 +104,17 @@ public class AeroProjectControllerTest
                 .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
                 .andExpect(jsonPath("$.messages").isEmpty());
 
-        adminActor.createProject("project1") //
-                .andExpect(status().isCreated()) //
+        var project = adminActor.toRProject(adminActor.createProject("project1") //
                 .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
-                .andExpect(jsonPath("$.body.id").value("1")) //
-                .andExpect(jsonPath("$.body.name").value("project1"));
+                .andExpect(jsonPath("$.body.name").value("project1")));
 
         adminActor.listProjects() //
                 .andExpect(status().isOk()) //
                 .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
-                .andExpect(jsonPath("$.body[0].id").value("1")) //
+                .andExpect(jsonPath("$.body[0].id").value(project.id())) //
                 .andExpect(jsonPath("$.body[0].name").value("project1"));
 
-        adminActor.deleteProject(1l) //
+        adminActor.deleteProject(project.id()) //
                 .andExpect(status().isOk()) //
                 .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
                 .andExpect(jsonPath("$.messages[0].level").value("INFO")) //
@@ -128,21 +129,159 @@ public class AeroProjectControllerTest
     @Test
     void testReadProjectByIdAndBySlug() throws Exception
     {
-        adminActor.createProject("project1") //
-                .andExpect(status().isCreated()) //
-                .andExpect(jsonPath("$.body.id").value("1"));
+        var project = adminActor.createProjectAndGet("project1");
 
-        adminActor.readProject(1l) //
+        // Addressing the project by its numeric ID and by its slug must resolve to the same
+        // project.
+        adminActor.readProject(project.id()) //
                 .andExpect(status().isOk()) //
                 .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
-                .andExpect(jsonPath("$.body.id").value("1")) //
+                .andExpect(jsonPath("$.body.id").value(project.id())) //
                 .andExpect(jsonPath("$.body.slug").value("project1"));
 
         adminActor.readProject("project1") //
                 .andExpect(status().isOk()) //
                 .andExpect(content().contentType(APPLICATION_JSON_VALUE)) //
-                .andExpect(jsonPath("$.body.id").value("1")) //
+                .andExpect(jsonPath("$.body.id").value(project.id())) //
                 .andExpect(jsonPath("$.body.slug").value("project1"));
+    }
+
+    @Test
+    void testProjectResponseExposesRolesOfSessionOwner() throws Exception
+    {
+        var userActor = new MockAeroClient(context, "user", "USER", "REMOTE");
+        userRepository.create(new User("user", ROLE_USER, ROLE_REMOTE));
+
+        var project = adminActor.createProjectAndGet("project1");
+
+        adminActor.grantProjectRole(project.id(), "user", "MANAGER", "CURATOR") //
+                .andExpect(status().isOk());
+
+        // The roles must be those of the user making the request - not those of any other user.
+        // The admin holds all roles in this project, so reporting the admin's roles here would
+        // be detectable.
+        userActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body[0].roles", contains("CURATOR", "MANAGER")));
+
+        userActor.readProject(project.id()) //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body.roles", contains("CURATOR", "MANAGER")));
+    }
+
+    @Test
+    void testProjectsWithoutManagerRoleAreNotListedOrReadable() throws Exception
+    {
+        var userActor = new MockAeroClient(context, "user", "USER", "REMOTE");
+        userRepository.create(new User("user", ROLE_USER, ROLE_REMOTE));
+
+        var project = adminActor.createProjectAndGet("project1");
+
+        adminActor.grantProjectRole(project.id(), "user", "ANNOTATOR", "CURATOR") //
+                .andExpect(status().isOk());
+
+        // The whole remote API requires the manager role, so a user who is merely an annotator or
+        // curator in a project must not see it in the project list at all.
+        userActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body").isEmpty());
+
+        userActor.readProject(project.id()) //
+                .andExpect(status().isForbidden());
+
+        userActor.readProject("project1") //
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void testProjectListReportsOnlyManagedProjects() throws Exception
+    {
+        var userActor = new MockAeroClient(context, "user", "USER", "REMOTE");
+        userRepository.create(new User("user", ROLE_USER, ROLE_REMOTE));
+
+        var managedProject = adminActor.createProjectAndGet("managed");
+        var annotatedProject = adminActor.createProjectAndGet("annotated");
+        adminActor.createProject("unrelated") //
+                .andExpect(status().isCreated());
+
+        adminActor.grantProjectRole(managedProject.id(), "user", "MANAGER") //
+                .andExpect(status().isOk());
+        adminActor.grantProjectRole(annotatedProject.id(), "user", "ANNOTATOR", "CURATOR") //
+                .andExpect(status().isOk());
+
+        // Only the project in which the user is a manager may be reported - not the one where
+        // they are merely an annotator/curator and not the one they have no roles in at all.
+        userActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body", hasSize(1))) //
+                .andExpect(jsonPath("$.body[0].slug").value("managed")) //
+                .andExpect(jsonPath("$.body[0].roles", contains("MANAGER")));
+
+        // The administrator sees all projects, including those without any roles.
+        adminActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body", hasSize(3)));
+    }
+
+    @Test
+    void testProjectResponseReportsNoRolesForAdminWithoutRoles() throws Exception
+    {
+        userRepository.create(new User("user", ROLE_USER, ROLE_REMOTE));
+
+        // Create the project on behalf of the other user so that the admin ends up without any
+        // roles in it - an admin creating a project for themselves would receive all roles.
+        var project = adminActor.createProjectForCreatorAndGet("project1", "user");
+
+        // The admin can access the project but holds no explicitly assigned roles in it, so the
+        // roles must be reported as empty rather than being omitted or guessed from the access.
+        adminActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body[0].roles").isArray()) //
+                .andExpect(jsonPath("$.body[0].roles").isEmpty());
+
+        adminActor.readProject(project.id()) //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.body.roles").isEmpty());
+    }
+
+    @Test
+    void testProjectRolesAreReportedInStableOrder() throws Exception
+    {
+        var userActor = new MockAeroClient(context, "user", "USER", "REMOTE");
+        userRepository.create(new User("user", ROLE_USER, ROLE_REMOTE));
+
+        var project = adminActor.createProjectAndGet("project1");
+
+        // Assign the roles in an order which differs from the order in which they must be
+        // reported so that the sorting is actually detectable.
+        adminActor.grantProjectRole(project.id(), "user", "CURATOR", "MANAGER", "ANNOTATOR") //
+                .andExpect(status().isOk());
+
+        userActor.listProjects() //
+                .andExpect(status().isOk()) //
+                .andExpect(
+                        jsonPath("$.body[0].roles", contains("ANNOTATOR", "CURATOR", "MANAGER")));
+    }
+
+    @Test
+    void testCreateProjectForCreatorReportsRolesOfCreator() throws Exception
+    {
+        userRepository.create(new User("user", ROLE_USER, ROLE_REMOTE));
+
+        // When an administrator creates a project on behalf of somebody else, it is that other
+        // user who receives the roles - so it is their roles which must be reported. Reporting
+        // the roles of the administrator would always yield an empty list here.
+        adminActor.createProjectForCreator("project1", "user") //
+                .andExpect(status().isCreated()) //
+                .andExpect(jsonPath("$.body.roles", contains("ANNOTATOR", "CURATOR", "MANAGER")));
+    }
+
+    @Test
+    void testCreateProjectReportsOwnRolesWhenNoCreatorGiven() throws Exception
+    {
+        adminActor.createProject("project1") //
+                .andExpect(status().isCreated()) //
+                .andExpect(jsonPath("$.body.roles", contains("ANNOTATOR", "CURATOR", "MANAGER")));
     }
 
     @Test

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/LegacyRemoteApiControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/LegacyRemoteApiControllerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero;
+
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_REMOTE;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationEventPublisher;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.legacy.LegacyRemoteApiController;
+import de.tudarmstadt.ukp.inception.search.config.SearchServiceAutoConfiguration;
+import de.tudarmstadt.ukp.inception.support.deployment.DeploymentModeServiceImpl;
+
+/**
+ * Tests for the deprecated legacy remote API. This test lives in the {@code aero} package so that
+ * it can reuse {@link MockAeroClient} for setting up projects and permissions.
+ */
+@ActiveProfiles(DeploymentModeServiceImpl.PROFILE_AUTH_MODE_DATABASE)
+@SpringBootTest( //
+        webEnvironment = WebEnvironment.MOCK, //
+        properties = { //
+                "spring.main.banner-mode=off", //
+                "search.enabled=false", //
+                "remote-api.enabled=true", //
+                "remote-api.legacy.enabled=true" })
+@EnableWebSecurity
+@EnableAutoConfiguration( //
+        exclude = { //
+                SearchServiceAutoConfiguration.class })
+@EntityScan({ //
+        "de.tudarmstadt.ukp.inception", //
+        "de.tudarmstadt.ukp.clarin.webanno" })
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class LegacyRemoteApiControllerTest
+{
+    static @TempDir Path tempFolder;
+
+    @DynamicPropertySource
+    static void registerDynamicProperties(DynamicPropertyRegistry registry)
+    {
+        registry.add("repository.path", () -> tempFolder.toAbsolutePath().toString());
+    }
+
+    private @Autowired WebApplicationContext context;
+    private @Autowired UserDao userRepository;
+
+    private MockAeroClient adminActor;
+
+    @BeforeEach
+    void setup()
+    {
+        adminActor = new MockAeroClient(context, "admin", "ADMIN", "REMOTE");
+
+        userRepository.create(new User("admin", ROLE_ADMIN, ROLE_REMOTE));
+    }
+
+    private ResultActions legacyListProjects(String aUser, String... aRoles) throws Exception
+    {
+        return MockMvcBuilders.webAppContextSetup(context) //
+                .apply(SecurityMockMvcConfigurers.springSecurity()) //
+                .build() //
+                .perform(get(LegacyRemoteApiController.API_BASE + "/projects") //
+                        .with(user(aUser).roles(aRoles)));
+    }
+
+    @Test
+    void testProjectListReportsOnlyManagedProjects() throws Exception
+    {
+        userRepository.create(new User("user", ROLE_USER, ROLE_REMOTE));
+
+        adminActor.createProject("managed") //
+                .andExpect(status().isCreated());
+        adminActor.createProject("annotated") //
+                .andExpect(status().isCreated());
+        adminActor.createProject("unrelated") //
+                .andExpect(status().isCreated());
+
+        adminActor.grantProjectRole(1, "user", "MANAGER") //
+                .andExpect(status().isOk());
+        adminActor.grantProjectRole(2, "user", "ANNOTATOR", "CURATOR") //
+                .andExpect(status().isOk());
+
+        // Only the project in which the user is a manager may be reported - not the one where
+        // they are merely an annotator/curator and not the one they have no roles in at all. The
+        // projects are keyed by their numeric ID in the legacy response format.
+        legacyListProjects("user", "USER", "REMOTE") //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.1.managed").exists()) //
+                .andExpect(jsonPath("$.2").doesNotExist()) //
+                .andExpect(jsonPath("$.3").doesNotExist());
+    }
+
+    @Test
+    void testProjectListReportsAllProjectsForAdministrator() throws Exception
+    {
+        adminActor.createProject("project1") //
+                .andExpect(status().isCreated());
+        adminActor.createProject("project2") //
+                .andExpect(status().isCreated());
+
+        // The administrator sees all projects.
+        legacyListProjects("admin", "ADMIN", "REMOTE") //
+                .andExpect(status().isOk()) //
+                .andExpect(jsonPath("$.1.project1").exists()) //
+                .andExpect(jsonPath("$.2.project2").exists());
+    }
+
+    @SpringBootConfiguration
+    public static class TestContext
+    {
+        @Bean
+        AuthenticationEventPublisher authenticationEventPublisher()
+        {
+            return new DefaultAuthenticationEventPublisher();
+        }
+    }
+}

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/MockAeroClient.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/MockAeroClient.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -35,9 +36,13 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RProject;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RResponse;
 import de.tudarmstadt.ukp.inception.annotation.storage.OpenCasStorageSessionForRequestFilter;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import de.tudarmstadt.ukp.inception.support.logging.LoggingFilter;
+import tools.jackson.core.type.TypeReference;
 
 class MockAeroClient
 {
@@ -114,6 +119,52 @@ class MockAeroClient
                 .with(user(username).roles(roles)) //
                 .param("slug", aSlug) //
                 .param("title", aTitle));
+    }
+
+    ResultActions createProjectForCreator(String aSlug, String aCreator) throws Exception
+    {
+        return mvc.perform(post(API_BASE + "/projects") //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)) //
+                .param("slug", aSlug) //
+                .param("creator", aCreator));
+    }
+
+    /**
+     * Create a project and return it as the server reported it back - in particular including the
+     * ID which the server assigned to it. Tests must operate on this ID instead of assuming that
+     * the identity sequence starts over for every test method.
+     */
+    RProject createProjectAndGet(String aSlug) throws Exception
+    {
+        return toRProject(createProject(aSlug));
+    }
+
+    /**
+     * @see #createProjectAndGet(String)
+     */
+    RProject createProjectForCreatorAndGet(String aSlug, String aCreator) throws Exception
+    {
+        return toRProject(createProjectForCreator(aSlug, aCreator));
+    }
+
+    /**
+     * Assert that a project was created and deserialize it from the response body. Use this when
+     * the test also needs to make assertions on the creation response itself - otherwise prefer
+     * {@link #createProjectAndGet(String)}.
+     */
+    RProject toRProject(ResultActions aResult) throws Exception
+    {
+        var response = aResult //
+                .andExpect(status().isCreated()) //
+                .andReturn() //
+                .getResponse() //
+                .getContentAsString();
+        return JSONUtil.getObjectMapper() //
+                .readValue(response, new TypeReference<RResponse<RProject>>()
+                {
+                }) //
+                .getBody();
     }
 
     /**


### PR DESCRIPTION
**What's in the PR**
- Convert RProject from a mutable class to a record with a builder, enabling deserialization by Jackson without additional constructors
- Add explicit PermissionLevel role arguments to getProject(...) and createCompatibleCas(...) calls across all AERO remote API controllers (AeroAnnotationController, AeroCurationController, AeroDocumentController, AeroKnowledgeBaseController, AeroProjectController, LegacyRemoteApiController, and related Controller_ImplBase/next/* classes)
- Update test helper MockAeroClient to deserialize and return RProject objects instead of extracting IDs via jsonPath
- Convert AeroProjectControllerTest call sites to use project object references instead of extracting IDs inline, eliminating hardcoded project ID assumptions that break when the database identity sequence is non-sequential
- Add LegacyRemoteApiControllerTest (new file)
- Clean up static import usage and logger modifier (`private` -> `private static`)

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
