### PR TITLE
#6214 - Error when using concept features in a project also using document-level annotations

### DIFF
--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.html
@@ -47,7 +47,7 @@
       </div>
     </div>
     <div class="flex-grow-1 flex-v-container">
-      <ul wicket:id="layersContainer" class="scrolling flex-content list-group list-group-flush">
+      <ul wicket:id="layersContainer" class="scrolling preserve-scroll flex-content list-group list-group-flush">
         <li wicket:id="layers" class="list-group-item py-0 px-0 border-0">
           <div class="px-2 py-1 bg-light-subtle fw-bold sticky-top border-top border-bottom">
             <wicket:container wicket:id="layerName"/>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStep.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStep.java
@@ -24,8 +24,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.AnnotationBase;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,8 +141,10 @@ public class KbLabelCachePrewarmStep
             return;
         }
 
-        for (var fs : aCas.<Annotation> select(type)) {
-            if (!overlapping(fs, aWindowBegin, aWindowEnd)) {
+        // Document-level layers are AnnotationBase subtypes without offsets - they are always
+        // in the window, so the overlap check applies only to proper Annotations.
+        for (var fs : aCas.<AnnotationBase> select(type)) {
+            if (fs instanceof Annotation ann && !overlapping(ann, aWindowBegin, aWindowEnd)) {
                 continue;
             }
             for (var info : featureInfos) {
@@ -163,7 +166,7 @@ public class KbLabelCachePrewarmStep
         return null;
     }
 
-    private void extractKeys(FeatureInfo aInfo, AnnotationFS aFs, Set<Key> aOut)
+    private void extractKeys(FeatureInfo aInfo, FeatureStructure aFs, Set<Key> aOut)
     {
         var feature = aInfo.feature();
         if (!aInfo.isMulti()) {


### PR DESCRIPTION
**What's in the PR**
- Fix ClassCastException when loading annotations on documents with document-level layers by selecting over AnnotationBase instead of Annotation, with window-overlap check only for offset-bearing annotations
- Add preserve-scroll CSS class to document metadata annotation list to prevent jumps

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
