### PR TITLE
#6220 - Live updates in the annotation sidebar stop arriving or show another user's view

### DIFF
--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
@@ -33,6 +33,7 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamJavaScriptReference;
 import de.tudarmstadt.ukp.inception.diam.model.compactv2.CompactSerializerV2Impl;
@@ -51,6 +52,7 @@ public class DiamAnnotationBrowser
     private @SpringBean ServletContext servletContext;
     private @SpringBean PreferencesService userPrefService;
     private @SpringBean AnnotationEditorExtensionRegistry extensionRegistry;
+    private @SpringBean UserDao userService;
 
     private final String userPreferencesKey;
     private final ContextMenu contextMenu;
@@ -80,7 +82,9 @@ public class DiamAnnotationBrowser
 
         var state = findParent(AnnotationPageBase.class).getModelObject();
 
-        if (state.getDocument() == null) {
+        var sessionOwner = userService.getCurrentUsername();
+
+        if (state.getDocument() == null || sessionOwner == null) {
             setDefaultModel(null);
             return;
         }
@@ -88,6 +92,7 @@ public class DiamAnnotationBrowser
         var viewport = ViewportDefinition.builder() //
                 .withDocument(state.getDocument()) //
                 .withDataOwner(state.getUser().getUsername()) //
+                .withSessionOwner(sessionOwner) //
                 .withFormat(CompactSerializerV2Impl.ID) //
                 .build();
 

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.diam.editor.config;
 
+import static de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController.PARAM_SESSION_OWNER;
+import static de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController.TOPIC_ELEMENT_SESSION_OWNER;
 import static de.tudarmstadt.ukp.inception.websocket.config.MessageExpressionAuthorizationManager.expression;
 import static de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants.PARAM_DOCUMENT;
 import static de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants.PARAM_PROJECT;
@@ -225,9 +227,24 @@ public class DiamAutoConfig
         return (aBuilder, aMAH) -> {
             LOG.debug("Configuring websocket security for annotation editor controller");
 
-            final var annotationEditorTopic = TOPIC_ELEMENT_PROJECT + "{" + PARAM_PROJECT + "}"
+            final var annotationEditorBaseTopic = TOPIC_ELEMENT_PROJECT + "{" + PARAM_PROJECT + "}"
                     + TOPIC_ELEMENT_DOCUMENT + "{" + PARAM_DOCUMENT + "}" + TOPIC_ELEMENT_USER + "{"
-                    + PARAM_USER + "}/**";
+                    + PARAM_USER + "}";
+
+            final var annotationEditorTopic = annotationEditorBaseTopic + "/**";
+
+            final var viewportTopic = annotationEditorBaseTopic + TOPIC_ELEMENT_SESSION_OWNER + "{"
+                    + PARAM_SESSION_OWNER + "}/**";
+
+            final var canViewAsSelf = "@documentAccess.canViewAnnotationDocument(#" + PARAM_PROJECT
+                    + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ") and #" + PARAM_SESSION_OWNER
+                    + " == authentication.name";
+
+            aBuilder.simpSubscribeDestMatchers("/app" + viewportTopic)
+                    .access(expression(aMAH, canViewAsSelf));
+
+            aBuilder.simpSubscribeDestMatchers("/topic" + viewportTopic)
+                    .access(expression(aMAH, canViewAsSelf));
 
             aBuilder.simpSubscribeDestMatchers("/app" + annotationEditorTopic)
                     .access(expression(aMAH, "@documentAccess.canViewAnnotationDocument(#"
@@ -236,14 +253,6 @@ public class DiamAutoConfig
             aBuilder.simpSubscribeDestMatchers("/topic" + annotationEditorTopic)
                     .access(expression(aMAH, "@documentAccess.canViewAnnotationDocument(#"
                             + PARAM_PROJECT + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ")"));
-
-            // aBuilder.simpSubscribeDestMatchers("/user/queue" + annotationEditorTopic)
-            // .access(expression(aMAH, "@documentAccess.canViewAnnotationDocument(#"
-            // + PARAM_PROJECT + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ")"));
-
-            // aBuilder.simpMessageDestMatchers(annotationEditorTopic)
-            // .access(expression(aMAH, "@documentAccess.canEditAnnotationDocument(#"
-            // + PARAM_PROJECT + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ")"));
         };
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportDefinition.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportDefinition.java
@@ -45,6 +45,7 @@ public class ViewportDefinition
     private final long projectId;
     private final long documentId;
     private final String dataOwner;
+    private final String sessionOwner;
 
     private final int begin;
     private final int end;
@@ -57,6 +58,7 @@ public class ViewportDefinition
         projectId = builder.projectId;
         documentId = builder.documentId;
         dataOwner = builder.dataOwner;
+        sessionOwner = builder.sessionOwner;
         begin = builder.begin;
         end = builder.end;
         format = builder.format;
@@ -84,9 +86,19 @@ public class ViewportDefinition
         return documentId;
     }
 
-    public String getUser()
+    public String getDataOwner()
     {
         return dataOwner;
+    }
+
+    /**
+     * @return the user who subscribed to this viewport, captured at subscribe time where the STOMP
+     *         principal is reliable. Renders triggered by a CAS write must use this rather than
+     *         looking the session owner up from the calling thread.
+     */
+    public String getSessionOwner()
+    {
+        return sessionOwner;
     }
 
     public int getBegin()
@@ -115,6 +127,7 @@ public class ViewportDefinition
         properties.setProperty(WebSocketConstants.PARAM_PROJECT, String.valueOf(projectId));
         properties.setProperty(WebSocketConstants.PARAM_DOCUMENT, String.valueOf(documentId));
         properties.setProperty(WebSocketConstants.PARAM_USER, dataOwner);
+        properties.setProperty(DiamWebsocketController.PARAM_SESSION_OWNER, sessionOwner);
         properties.setProperty(DiamWebsocketController.PARAM_FROM, String.valueOf(begin));
         properties.setProperty(DiamWebsocketController.PARAM_TO, String.valueOf(end));
         return DiamWebsocketController.PLACEHOLDER_RESOLVER.replacePlaceholders(
@@ -131,6 +144,7 @@ public class ViewportDefinition
         return new EqualsBuilder() //
                 .append(documentId, castOther.documentId) //
                 .append(dataOwner, castOther.dataOwner) //
+                .append(sessionOwner, castOther.sessionOwner) //
                 .append(begin, castOther.begin) //
                 .append(end, castOther.end) //
                 .append(format, castOther.format) //
@@ -144,6 +158,7 @@ public class ViewportDefinition
         return new HashCodeBuilder() //
                 .append(documentId) //
                 .append(dataOwner) //
+                .append(sessionOwner) //
                 .append(begin) //
                 .append(end) //
                 .append(format) //
@@ -157,6 +172,7 @@ public class ViewportDefinition
         return new ToStringBuilder(this, NO_CLASS_NAME_STYLE) //
                 .append("documentId", documentId) //
                 .append("user", dataOwner) //
+                .append("sessionOwner", sessionOwner) //
                 .append("begin", begin) //
                 .append("end", end) //
                 .append("format", format) //
@@ -174,6 +190,7 @@ public class ViewportDefinition
         private long projectId;
         private long documentId;
         private String dataOwner;
+        private String sessionOwner;
         private int begin = 0;
         private int end = Integer.MAX_VALUE;
         private String format;
@@ -212,6 +229,12 @@ public class ViewportDefinition
         public Builder withDataOwner(String aDataOwner)
         {
             dataOwner = aDataOwner;
+            return this;
+        }
+
+        public Builder withSessionOwner(String aSessionOwner)
+        {
+            sessionOwner = aSessionOwner;
             return this;
         }
 
@@ -263,6 +286,10 @@ public class ViewportDefinition
             if (dataOwner == null) {
                 throw new IllegalStateException(
                         "Cannot build ViewportDefinition: dataOwner must not be null");
+            }
+            if (sessionOwner == null) {
+                throw new IllegalStateException(
+                        "Cannot build ViewportDefinition: sessionOwner must not be null");
             }
             if (format == null) {
                 throw new IllegalStateException(

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.diam.service;
 
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.fromJsonString;
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.toJsonString;
 import static de.tudarmstadt.ukp.inception.support.logging.Logging.KEY_REPOSITORY_PATH;
@@ -102,6 +103,9 @@ public class DiamWebsocketController
     public static final String PARAM_FROM = "from";
     public static final String PARAM_TO = "to";
     public static final String PARAM_FORMAT = "format";
+    public static final String PARAM_SESSION_OWNER = "sessionOwner";
+
+    public static final String TOPIC_ELEMENT_SESSION_OWNER = "/as/";
 
     public static final PropertyPlaceholderHelper PLACEHOLDER_RESOLVER = new PropertyPlaceholderHelper(
             "{", "}", null, '\\', false);
@@ -111,7 +115,8 @@ public class DiamWebsocketController
             + TOPIC_ELEMENT_USER + "{" + PARAM_USER + "}";
 
     public static final String DOCUMENT_VIEWPORT_TOPIC_TEMPLATE = //
-            DOCUMENT_BASE_TOPIC_TEMPLATE + "/from/{" + PARAM_FROM + "}/to/{" + PARAM_TO + "}";
+            DOCUMENT_BASE_TOPIC_TEMPLATE + TOPIC_ELEMENT_SESSION_OWNER + "{" + PARAM_SESSION_OWNER
+                    + "}" + "/from/{" + PARAM_FROM + "}/to/{" + PARAM_TO + "}";
 
     // public static final String ANNOTATION_COMMAND_DELETE_TOPIC_TEMPLATE = //
     // DOCUMENT_BASE_TOPIC_TEMPLATE + "/delete";
@@ -226,10 +231,17 @@ public class DiamWebsocketController
             @DestinationVariable(PARAM_PROJECT) long aProjectId,
             @DestinationVariable(PARAM_DOCUMENT) long aDocumentId,
             @DestinationVariable(PARAM_USER) String aDataOwner,
+            @DestinationVariable(PARAM_SESSION_OWNER) String aSessionOwner,
             @DestinationVariable(PARAM_FROM) int aViewportBegin,
             @DestinationVariable(PARAM_TO) int aViewportEnd)
         throws IOException
     {
+        // The PARAM_SESSION_OWNER only exists to disambiguate the topics. It is checked for
+        // consistency with the principal but otherwise not used.
+        var sessionOwner = aPrincipal.getName();
+        assertPermission("User [" + sessionOwner + "] cannot subscribe to a viewport of user ["
+                + aSessionOwner + "]", sessionOwner.equals(aSessionOwner));
+
         var project = getProject(aProjectId);
 
         try (var session = CasStorageSession.open()) {
@@ -249,6 +261,7 @@ public class DiamWebsocketController
                     .withProjectId(aProjectId) //
                     .withDocumentId(aDocumentId) //
                     .withDataOwner(aDataOwner) //
+                    .withSessionOwner(sessionOwner) //
                     .withRange(aViewportBegin, aViewportEnd) //
                     .withFormat(format) //
                     .enabledExtensions(enabledExtensions) //
@@ -275,15 +288,26 @@ public class DiamWebsocketController
     private JsonNode render(Project aProject, ViewportDefinition aVpd) throws IOException
     {
         var doc = documentService.getSourceDocument(aProject.getId(), aVpd.getDocumentId());
-        var sessionOwner = userRepository.getCurrentUsername();
-        var dataOwner = userRepository.getUserOrCurationUser(aVpd.getUser());
+        var sessionOwnerName = aVpd.getSessionOwner();
+        if (sessionOwnerName == null) {
+            throw new IllegalStateException(
+                    "Viewport [" + aVpd + "] has no session owner - it was not created through "
+                            + "the subscribe handler and cannot be rendered.");
+        }
+
+        var sessionOwner = userRepository.get(sessionOwnerName);
+        if (sessionOwner == null) {
+            throw new IllegalStateException("Session owner [" + sessionOwnerName + "] of viewport ["
+                    + aVpd + "] no longer exists.");
+        }
+        var dataOwner = userRepository.getUserOrCurationUser(aVpd.getDataOwner());
 
         var constraints = constraintsService.getMergedConstraints(aProject);
 
-        var cas = documentService.readAnnotationCas(doc, AnnotationSet.forUser(aVpd.getUser()));
+        var cas = documentService.readAnnotationCas(doc, annotationSetFor(aVpd.getDataOwner()));
 
-        var prefs = userPreferencesService.loadPreferences(doc.getProject(), sessionOwner,
-                Mode.ANNOTATION);
+        var prefs = userPreferencesService.loadPreferences(doc.getProject(),
+                sessionOwner.getUsername(), Mode.ANNOTATION);
 
         var layers = schemaService.listSupportedLayers(aProject).stream()
                 .filter(AnnotationLayer::isEnabled) //
@@ -293,7 +317,7 @@ public class DiamWebsocketController
         var allLayers = schemaService.listAnnotationLayer(aProject);
 
         var request = RenderRequest.builder() //
-                .withSessionOwner(userRepository.getCurrentUser()) //
+                .withSessionOwner(sessionOwner) //
                 .withDocument(doc, dataOwner) //
                 .withConstraints(constraints) //
                 .withWindow(aVpd.getBegin(), aVpd.getEnd()) //
@@ -314,6 +338,15 @@ public class DiamWebsocketController
                         "Unsupported format [" + aVpd.getFormat() + "]"));
 
         return JSONUtil.getObjectMapper().valueToTree(serializer.render(vdoc, request));
+    }
+
+    private AnnotationSet annotationSetFor(String aDataOwner)
+    {
+        if (CURATION_USER.equals(aDataOwner)) {
+            return AnnotationSet.CURATION_SET;
+        }
+
+        return AnnotationSet.forUser(aDataOwner);
     }
 
     private ViewportState initState(ViewportDefinition aVpd)
@@ -347,9 +380,11 @@ public class DiamWebsocketController
             return;
         }
 
-        // MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+        var previousRepositoryPath = MDC.get(KEY_REPOSITORY_PATH);
 
         try (var session = CasStorageSession.openNested()) {
+            MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+
             var project = projectService.getProject(vpd.getProjectId());
             var newJson = render(project, vpd);
 
@@ -374,12 +409,16 @@ public class DiamWebsocketController
                     new MViewportUpdate(aUpdateBegin, aUpdateEnd, diff), sha.getMessageHeaders());
         }
         catch (Exception ex) {
-            LOG.error("Unable to render update", ex);
+            LOG.error("Unable to render update for document {} - {}", aDoc, vpd, ex);
         }
-
-        // finally {
-        // MDC.remove(KEY_REPOSITORY_PATH);
-        // }
+        finally {
+            if (previousRepositoryPath != null) {
+                MDC.put(KEY_REPOSITORY_PATH, previousRepositoryPath);
+            }
+            else {
+                MDC.remove(KEY_REPOSITORY_PATH);
+            }
+        }
     }
 
     private Project getProject(long aProjectId) throws AccessDeniedException

--- a/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
+++ b/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
@@ -18,15 +18,20 @@
 package de.tudarmstadt.ukp.inception.diam.service;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController.FORMAT_LEGACY;
 import static de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController.X_DIAM_FORMAT;
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.fromJsonString;
 import static de.tudarmstadt.ukp.inception.websocket.config.WebsocketConfig.WS_ENDPOINT;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.Duration.ofSeconds;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.messaging.simp.SimpMessageHeaderAccessor.DESTINATION_HEADER;
 import static org.springframework.messaging.simp.SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER;
@@ -36,6 +41,9 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 import java.io.File;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.AfterEach;
@@ -57,15 +65,22 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.AnnotationAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.PreRenderer;
@@ -145,7 +160,10 @@ public class DiamWebsocketController_ViewportRoutingTest
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String USER = "user";
+    private static final String CURATOR_USER = "curator";
     private static final String PASS = "pass";
+
+    private static final AtomicInteger sessionCounter = new AtomicInteger();
 
     private @LocalServerPort int port;
     private String websocketUrl;
@@ -162,6 +180,7 @@ public class DiamWebsocketController_ViewportRoutingTest
     private static @TempDir File repositoryDir;
 
     private static User user;
+    private static User otherUser;
     private static Project testProject;
     private static AnnotationLayer testLayer;
     private static SourceDocument testDoc;
@@ -188,9 +207,14 @@ public class DiamWebsocketController_ViewportRoutingTest
         user.setPassword(PASS);
         userService.create(user);
 
+        otherUser = new User(CURATOR_USER, ROLE_USER);
+        otherUser.setPassword(PASS);
+        userService.create(otherUser);
+
         testProject = new Project("test-project");
         projectService.createProject(testProject);
         projectService.assignRole(testProject, user, ANNOTATOR);
+        projectService.assignRole(testProject, otherUser, CURATOR);
 
         testLayer = new AnnotationLayer();
         testLayer.setProject(testProject);
@@ -220,11 +244,13 @@ public class DiamWebsocketController_ViewportRoutingTest
     public void thatViewportBasedMessageRoutingWorks() throws Exception
     {
         var vpd1 = ViewportDefinition.builder() //
+                .withSessionOwner(USER) //
                 .withDocument(testAnnotationDocument) //
                 .withRange(10, 20) //
                 .withFormat(FORMAT_LEGACY) //
                 .build();
         var vpd2 = ViewportDefinition.builder() //
+                .withSessionOwner(USER) //
                 .withDocument(testAnnotationDocument) //
                 .withRange(30, 40) //
                 .withFormat(FORMAT_LEGACY) //
@@ -334,6 +360,424 @@ public class DiamWebsocketController_ViewportRoutingTest
 
             client1.assertExpectations();
             client2.assertExpectations();
+        }
+    }
+
+    /**
+     * The CAS may be written by a thread that carries no security context at all - most commonly a
+     * scheduler thread - the scheduling module does no {@code SecurityContext} propagation, so a
+     * bulk prediction or bulk curation task writing a CAS has none.
+     * {@link DiamWebsocketController#sendUpdate} runs synchronously on that thread, so anything it
+     * derives from {@link SecurityContextHolder} is unavailable there. The subscriber's own render
+     * must still be pushed.
+     */
+    @WithMockUser(username = USER, roles = { "USER" })
+    @Test
+    public void thatUpdateIsPushedWhenCasIsWrittenWithoutSecurityContext() throws Exception
+    {
+        var vpd = ViewportDefinition.builder() //
+                .withSessionOwner(USER) //
+                .withDocument(testAnnotationDocument) //
+                .withRange(0, 20) //
+                .withFormat(FORMAT_LEGACY) //
+                .build();
+
+        testPreRenderer.setRenderFunc((aResponse,
+                aRequest) -> aResponse.add(new VSpan(testLayer, new VID(1),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap())));
+
+        try (var client = new WebSocketStompTestClient(USER, PASS)) {
+            client.expectSuccessfulConnection().connect(websocketUrl);
+            client.subscribe("/topic" + vpd.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd.getFormat() + "'"));
+            client.expect(MViewportInit.class, msg -> assertThat(msg.getText()).isNotEmpty());
+            // The /app subscription is what actually invokes @SubscribeMapping and thereby
+            // registers the viewport server-side. Subscribing only to /topic yields a client that
+            // is listening but a server that has no viewport to push to.
+            client.subscribe("/app" + vpd.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd.getFormat() + "'"));
+
+            var expected = new MViewportUpdate(0, 20, fromJsonString(
+                    "[{\"op\":\"replace\",\"path\":\"/spans/0/vid\",\"value\":\"2\"}]"));
+            client.expect(MViewportUpdate.class, update -> assertThat(update).isEqualTo(expected));
+
+            testPreRenderer.setRenderFunc((aResponse, aRequest) -> aResponse.add(new VSpan(
+                    testLayer, new VID(2),
+                    new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                    emptyMap())));
+
+            // Emulate a scheduler thread (e.g. BulkPredictionTask) writing the CAS: no security
+            // context whatsoever. Note that a plain `new Thread(...)` inherits nothing here
+            // because MODE_INHERITABLETHREADLOCAL is not configured anywhere in the code base.
+            runInThreadWithoutSecurityContext(() -> sut.sendUpdate(testAnnotationDocument, 0, 20));
+
+            client.assertExpectations();
+        }
+    }
+
+    /**
+     * Another user writing the document must not cause <b>their</b> session to be used for
+     * rendering the subscriber's viewport - that would render the writer's layer visibility and
+     * preferences into the payload pushed to the subscriber. Routine in curation and on shared
+     * annotation sets.
+     */
+    @WithMockUser(username = USER, roles = { "USER" })
+    @Test
+    public void thatUpdateIsPushedAsSubscriberWhenOtherUserWritesCas() throws Exception
+    {
+        var vpd = ViewportDefinition.builder() //
+                .withSessionOwner(USER) //
+                .withDocument(testAnnotationDocument) //
+                .withRange(0, 20) //
+                .withFormat(FORMAT_LEGACY) //
+                .build();
+
+        testPreRenderer.setRenderFunc((aResponse,
+                aRequest) -> aResponse.add(new VSpan(testLayer, new VID(1),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap())));
+
+        try (var client = new WebSocketStompTestClient(USER, PASS)) {
+            client.expectSuccessfulConnection().connect(websocketUrl);
+            client.subscribe("/topic" + vpd.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd.getFormat() + "'"));
+            client.expect(MViewportInit.class, msg -> assertThat(msg.getText()).isNotEmpty());
+            // See the note on the /app subscription in the sibling test above.
+            client.subscribe("/app" + vpd.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd.getFormat() + "'"));
+
+            var expected = new MViewportUpdate(0, 20, fromJsonString(
+                    "[{\"op\":\"replace\",\"path\":\"/spans/0/vid\",\"value\":\"2\"}]"));
+            client.expect(MViewportUpdate.class, update -> assertThat(update).isEqualTo(expected));
+
+            // Capture whose session the render actually ran as.
+            var renderedAs = new AtomicReference<String>();
+            testPreRenderer.setRenderFunc((aResponse, aRequest) -> {
+                var sessionOwner = aRequest.getSessionOwner();
+                renderedAs.set(sessionOwner != null ? sessionOwner.getUsername() : null);
+                aResponse.add(new VSpan(testLayer, new VID(2),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap()));
+            });
+
+            runInThreadAs(CURATOR_USER, () -> sut.sendUpdate(testAnnotationDocument, 0, 20));
+
+            client.assertExpectations();
+
+            assertThat(renderedAs.get()) //
+                    .as("render must run as the subscriber, not as the user who wrote the CAS") //
+                    .isEqualTo(USER);
+        }
+    }
+
+    /**
+     * A curator and an annotator viewing the <b>same</b> annotator document must each get their own
+     * viewport and their own render. (An annotator may only view their own document, so the
+     * realistic two-viewer case is a curator or manager alongside the annotator - see
+     * {@code DocumentAccessImpl.canViewAnnotationDocument}.)
+     * <p>
+     * The CAS is viewer-independent, but the render is not: suggestions are fetched per session
+     * owner, colours come from the viewer's preferences, and the viewer's hidden layers decide what
+     * is serialized at all. The topic is keyed on the dataOwner, so without the session owner
+     * participating in {@link ViewportDefinition#equals} both viewers would collapse onto a single
+     * cache entry and whoever subscribed first would govern the render pushed to both.
+     */
+    @WithMockUser(username = USER, roles = { "USER" })
+    @Test
+    public void thatEachSessionOwnerGetsItsOwnViewport() throws Exception
+    {
+        var vpdUser = ViewportDefinition.builder() //
+                .withSessionOwner(USER) //
+                .withDocument(testAnnotationDocument) //
+                .withRange(0, 20) //
+                .withFormat(FORMAT_LEGACY) //
+                .build();
+        var vpdOther = ViewportDefinition.builder() //
+                .withSessionOwner(CURATOR_USER) //
+                .withDocument(testAnnotationDocument) //
+                .withRange(0, 20) //
+                .withFormat(FORMAT_LEGACY) //
+                .build();
+
+        // Same document, same dataOwner, same range, same format - differing only in who is
+        // looking. These must be neither the same viewport nor the same topic: updates are JSON
+        // patches against a per-viewport baseline, so sharing a topic would have each client apply
+        // the other's patch on top of its own document.
+        assertThat(vpdUser) //
+                .as("viewports of different session owners must not collide") //
+                .isNotEqualTo(vpdOther);
+        assertThat(vpdUser.getTopic()) //
+                .as("viewers must not share a topic - each would apply the other's patch") //
+                .isNotEqualTo(vpdOther.getTopic());
+
+        testPreRenderer.setRenderFunc((aResponse,
+                aRequest) -> aResponse.add(new VSpan(testLayer, new VID(1),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap())));
+
+        try (var client1 = new WebSocketStompTestClient(USER, PASS);
+                var client2 = new WebSocketStompTestClient(CURATOR_USER, PASS)) {
+            client1.expectSuccessfulConnection().connect(websocketUrl);
+            client1.subscribe("/topic" + vpdUser.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, FORMAT_LEGACY, //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + FORMAT_LEGACY + "'"));
+            client1.expect(MViewportInit.class, msg -> assertThat(msg.getText()).isNotEmpty());
+            client1.subscribe("/app" + vpdUser.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, FORMAT_LEGACY, //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + FORMAT_LEGACY + "'"));
+
+            client2.expectSuccessfulConnection().connect(websocketUrl);
+            client2.subscribe("/topic" + vpdOther.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, FORMAT_LEGACY, //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + FORMAT_LEGACY + "'"));
+            client2.expect(MViewportInit.class, msg -> assertThat(msg.getText()).isNotEmpty());
+            client2.subscribe("/app" + vpdOther.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, FORMAT_LEGACY, //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + FORMAT_LEGACY + "'"));
+
+            // Each client must receive EXACTLY ONE update - its own. Two viewports on one shared
+            // topic would deliver both diffs to both clients, and since the client applies every
+            // diff it receives (DiamWebsocketImpl), the second would be applied on top of an
+            // already-patched document and corrupt it.
+            var expected = new MViewportUpdate(0, 20, fromJsonString(
+                    "[{\"op\":\"replace\",\"path\":\"/spans/0/vid\",\"value\":\"2\"}]"));
+            client1.expectWithHeaders(MViewportUpdate.class, (message, update) -> {
+                assertThat(update).isEqualTo(expected);
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/topic" + vpdUser.getTopic());
+            });
+            client2.expectWithHeaders(MViewportUpdate.class, (message, update) -> {
+                assertThat(update).isEqualTo(expected);
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/topic" + vpdOther.getTopic());
+            });
+
+            // Collect the session owner of every render triggered by the update below. With one
+            // viewport per session owner we must see BOTH users represented.
+            var renderedAs = ConcurrentHashMap.<String> newKeySet();
+            testPreRenderer.setRenderFunc((aResponse, aRequest) -> {
+                var sessionOwner = aRequest.getSessionOwner();
+                renderedAs.add(sessionOwner != null ? sessionOwner.getUsername() : "<null>");
+                aResponse.add(new VSpan(testLayer, new VID(2),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap()));
+            });
+
+            runInThreadWithoutSecurityContext(() -> sut.sendUpdate(testAnnotationDocument, 0, 20));
+
+            await("both viewports rendered") //
+                    .atMost(ofSeconds(30)) //
+                    .until(() -> renderedAs.size() >= 2);
+
+            assertThat(renderedAs) //
+                    .as("each session owner must get their own render") //
+                    .containsExactlyInAnyOrder(USER, CURATOR_USER);
+
+            // assertExpectations() also fails on any *extra* message beyond those queued above -
+            // which is precisely what a shared topic would produce.
+            client1.assertExpectations();
+            client2.assertExpectations();
+        }
+    }
+
+    /**
+     * The session owner is part of the destination and is therefore client-supplied. Subscribing to
+     * another user's viewport topic must be rejected: that topic carries renders made with the
+     * other user's layer visibility and preferences.
+     * <p>
+     * Note that the surrounding {@code canViewAnnotationDocument} rule guards the <b>data owner</b>
+     * and so happily permits a curator subscribing to an annotator's document - only the
+     * session-owner check in the handler stops them subscribing <i>as</i> that annotator.
+     * <p>
+     * This drives the handler directly rather than through a STOMP client: the rejection closes the
+     * connection before any subscription is established, so there is nothing for the client to
+     * observe the error frame on.
+     */
+    @WithMockUser(username = CURATOR_USER, roles = { "USER" })
+    @Test
+    public void thatSubscribingToAnotherUsersViewportIsRejected() throws Exception
+    {
+        var headerAccessor = SimpMessageHeaderAccessor.create(SimpMessageType.SUBSCRIBE);
+        headerAccessor.setNativeHeader(X_DIAM_FORMAT, FORMAT_LEGACY);
+
+        // CURATOR_USER is allowed to view USER's document, but must not pose as USER.
+        assertThatExceptionOfType(AccessDeniedException.class) //
+                .isThrownBy(() -> sut.onSubscribeToViewport(headerAccessor,
+                        () -> CURATOR_USER /* principal */, testProject.getId(), testDoc.getId(),
+                        USER /* dataOwner */, USER /* sessionOwner */, 0, 20)) //
+                .withMessageContaining(CURATOR_USER) //
+                .withMessageContaining(USER);
+    }
+
+    /**
+     * The handler-level check in {@link #thatSubscribingToAnotherUsersViewportIsRejected()} only
+     * covers {@code /app} - {@code @SubscribeMapping} is dispatched for the application prefix
+     * only. The updates themselves are pushed to {@code /topic}, so subscribing there must be
+     * barred by the STOMP security rules as well: otherwise a curator can skip the {@code /app}
+     * subscription entirely and just listen in on the annotator's topic.
+     */
+    @WithMockUser(username = CURATOR_USER, roles = { "USER" })
+    @Test
+    public void thatSubscribingToAnotherUsersViewportTopicIsRejected() throws Exception
+    {
+        var vpd = ViewportDefinition.builder() //
+                .withSessionOwner(USER) //
+                .withDocument(testAnnotationDocument) //
+                .withRange(0, 20) //
+                .withFormat(FORMAT_LEGACY) //
+                .build();
+
+        // CURATOR_USER may view USER's document - canViewAnnotationDocument alone would let this
+        // through. Only the session-owner part of the rule stops it.
+        try (var client = new WebSocketStompTestClient(CURATOR_USER, PASS)) {
+            client.expectSuccessfulConnection().connect(websocketUrl);
+
+            client.expectError(
+                    "Failed to send message to ExecutorSubscribableChannel[clientInboundChannel]");
+            client.subscribeWithoutWaiting("/topic" + vpd.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, FORMAT_LEGACY));
+
+            client.assertExpectations();
+        }
+    }
+
+    /**
+     * The counterpart to {@link #thatSubscribingToAnotherUsersViewportIsRejected()}: subscribing to
+     * one's own viewport must of course still work.
+     */
+    @WithMockUser(username = USER, roles = { "USER" })
+    @Test
+    public void thatSubscribingToOwnViewportIsPermitted() throws Exception
+    {
+        testPreRenderer.setRenderFunc((aResponse,
+                aRequest) -> aResponse.add(new VSpan(testLayer, new VID(1),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap())));
+
+        var headerAccessor = subscribeHeaders();
+
+        try {
+            var result = sut.onSubscribeToViewport(headerAccessor, () -> USER /* principal */,
+                    testProject.getId(), testDoc.getId(), USER /* dataOwner */,
+                    USER /* sessionOwner */, 0, 20);
+
+            assertThat(result).as("subscribing to one's own viewport returns a render").isNotNull();
+        }
+        finally {
+            unsubscribe(headerAccessor);
+        }
+    }
+
+    /**
+     * When the CAS is written on a thread that already has an MDC - i.e. a request thread, which
+     * the servlet filter has set up - the update rendering must leave that MDC as it found it.
+     * {@code AfterCasWrittenEvent} is published synchronously from {@code writeAnnotationCas}, so
+     * the request carries on afterwards and would otherwise continue without a repository path.
+     */
+    @WithMockUser(username = USER, roles = { "USER" })
+    @Test
+    public void thatSendUpdateRestoresTheCallersMdc() throws Exception
+    {
+        testPreRenderer.setRenderFunc((aResponse,
+                aRequest) -> aResponse.add(new VSpan(testLayer, new VID(1),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap())));
+
+        // A viewport must actually be registered, otherwise sendUpdate matches nothing, the
+        // MDC-handling code never runs, and the assertion below would hold trivially.
+        var headerAccessor = subscribeHeaders();
+        sut.onSubscribeToViewport(headerAccessor, () -> USER, testProject.getId(), testDoc.getId(),
+                USER, USER, 0, 20);
+
+        var callersRepositoryPath = "/some/caller/owned/path";
+        var previous = MDC.get(Logging.KEY_REPOSITORY_PATH);
+        MDC.put(Logging.KEY_REPOSITORY_PATH, callersRepositoryPath);
+        try {
+            sut.sendUpdate(testAnnotationDocument, 0, 20);
+
+            assertThat(MDC.get(Logging.KEY_REPOSITORY_PATH)) //
+                    .as("sendUpdate must leave the caller's MDC untouched") //
+                    .isEqualTo(callersRepositoryPath);
+        }
+        finally {
+            unsubscribe(headerAccessor);
+
+            if (previous != null) {
+                MDC.put(Logging.KEY_REPOSITORY_PATH, previous);
+            }
+            else {
+                MDC.remove(Logging.KEY_REPOSITORY_PATH);
+            }
+        }
+    }
+
+    /**
+     * Headers for driving {@link DiamWebsocketController#onSubscribeToViewport} directly. The
+     * session and subscription ids matter: without them the viewport records a subscription with a
+     * {@code null} session id, which lives on in the shared viewport cache and makes
+     * {@code ViewportState.removeSubscriptionsBySession} throw when any later test disconnects.
+     */
+    private SimpMessageHeaderAccessor subscribeHeaders()
+    {
+        var headerAccessor = SimpMessageHeaderAccessor.create(SimpMessageType.SUBSCRIBE);
+        headerAccessor.setNativeHeader(X_DIAM_FORMAT, FORMAT_LEGACY);
+        headerAccessor.setSessionId("test-session-" + sessionCounter.incrementAndGet());
+        headerAccessor.setSubscriptionId("test-subscription");
+        return headerAccessor;
+    }
+
+    /**
+     * Drop the viewport registered via {@link #subscribeHeaders()} again so it cannot emit updates
+     * into subsequent tests - the viewport cache is shared across all tests in this class.
+     */
+    private void unsubscribe(SimpMessageHeaderAccessor aHeaderAccessor)
+    {
+        var message = MessageBuilder.createMessage(new byte[0],
+                aHeaderAccessor.getMessageHeaders());
+        sut.onSessionUnsubscribe(new SessionUnsubscribeEvent(this, message));
+    }
+
+    private void runInThreadWithoutSecurityContext(Runnable aRunnable) throws Exception
+    {
+        runInThread(aRunnable, null);
+    }
+
+    private void runInThreadAs(String aUsername, Runnable aRunnable) throws Exception
+    {
+        runInThread(aRunnable, aUsername);
+    }
+
+    private void runInThread(Runnable aRunnable, String aUsername) throws Exception
+    {
+        var error = new AtomicReference<Throwable>();
+        var thread = new Thread(() -> {
+            try {
+                SecurityContextHolder.clearContext();
+                if (aUsername != null) {
+                    var context = SecurityContextHolder.createEmptyContext();
+                    context.setAuthentication(
+                            new UsernamePasswordAuthenticationToken(aUsername, "N/A", emptyList()));
+                    SecurityContextHolder.setContext(context);
+                }
+                aRunnable.run();
+            }
+            catch (Throwable e) {
+                error.set(e);
+            }
+            finally {
+                SecurityContextHolder.clearContext();
+            }
+        });
+        thread.start();
+        thread.join();
+
+        if (error.get() != null) {
+            throw new AssertionError("Write thread failed", error.get());
         }
     }
 

--- a/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/websocket/WebSocketStompTestClient.java
+++ b/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/websocket/WebSocketStompTestClient.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.support.test.websocket;
 
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -45,6 +46,7 @@ import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableRunnable;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
@@ -70,8 +72,10 @@ public class WebSocketStompTestClient
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+    private static final Duration DEFAULT_MESSAGE_TIMEOUT = Duration.ofSeconds(30);
+
     private final Duration connectTimeout = Duration.ofSeconds(60);
-    private final Duration messageTimeout = Duration.ofHours(10);
+    private Duration messageTimeout = DEFAULT_MESSAGE_TIMEOUT;
 
     private final String username;
     private final String password;
@@ -209,7 +213,8 @@ public class WebSocketStompTestClient
     }
 
     /**
-     * Subscribes to a topic. Requires expected messages to be queued before.
+     * Subscribes to a topic and <b>waits</b> for the queued expectations to be satisfied. Requires
+     * expected messages to be queued before.
      * 
      * @param aTopic
      *            topic to subscribe to
@@ -219,15 +224,7 @@ public class WebSocketStompTestClient
      */
     public Subscription subscribe(String aTopic, Map<String, String> aHeaders)
     {
-        var headers = new StompHeaders();
-        headers.setDestination(aTopic);
-
-        if (aHeaders != null) {
-            headers.setAll(aHeaders);
-        }
-
-        var handler = new CapturingFrameHandler<>(Message.class, received);
-        var sub = session.subscribe(headers, handler);
+        var sub = subscribeWithoutWaiting(aTopic, aHeaders);
 
         waitForMessages();
 
@@ -236,6 +233,30 @@ public class WebSocketStompTestClient
         LOG.trace("Subscription to [{}] successful", aTopic);
 
         return sub;
+    }
+
+    /**
+     * Subscribes to a topic without waiting for any expectation to be satisfied. Use this when the
+     * subscription itself is what is under test - most notably when the server is expected to
+     * reject it - and then assert separately, e.g. via {@link #assertExpectations()}.
+     *
+     * @param aTopic
+     *            topic to subscribe to
+     * @param aHeaders
+     *            extra headers
+     * @return subscription.
+     */
+    public Subscription subscribeWithoutWaiting(String aTopic, Map<String, String> aHeaders)
+    {
+        var headers = new StompHeaders();
+        headers.setDestination(aTopic);
+
+        if (aHeaders != null) {
+            headers.setAll(aHeaders);
+        }
+
+        var handler = new CapturingFrameHandler<>(Message.class, received);
+        return session.subscribe(headers, handler);
     }
 
     public void perform(FailableRunnable<Exception> aTask) throws Exception
@@ -259,11 +280,42 @@ public class WebSocketStompTestClient
         handleExpectations();
     }
 
+    /**
+     * Raise (or lower) the time to wait for expected messages. Use when debugging interactively -
+     * the default is deliberately short so that a message which never arrives fails fast instead of
+     * hanging. See {@link #DEFAULT_MESSAGE_TIMEOUT}.
+     *
+     * @param aTimeout
+     *            how long to wait.
+     * @return this client, for chaining.
+     */
+    public WebSocketStompTestClient withMessageTimeout(Duration aTimeout)
+    {
+        messageTimeout = aTimeout;
+        return this;
+    }
+
     private void waitForMessages()
     {
-        await("all expected messages received") //
-                .atMost(messageTimeout) //
-                .until(() -> received.size() >= expectations.size());
+        try {
+            await("all expected messages received") //
+                    .atMost(messageTimeout) //
+                    .until(() -> received.size() >= expectations.size());
+        }
+        catch (ConditionTimeoutException e) {
+            // Awaitility's own message says only that a condition was not met. Report what was
+            // actually outstanding - without this, a missing message is near-undiagnosable.
+            throw new AssertionError(
+                    format("Timed out after %s waiting for messages: expected %d, received %d.%n"
+                            + "Outstanding expectations: %s%nReceived so far: %s%n"
+                            + "Note that a message may be missing because the server never sent it "
+                            + "(check the server log for errors) or because the subscription never "
+                            + "reached the server - remember that @SubscribeMapping handlers are "
+                            + "invoked by subscribing to /app<topic>, not /topic<topic>.",
+                            messageTimeout, expectations.size(), received.size(), expectations,
+                            received),
+                    e);
+        }
 
         await("extra time") //
                 .pollDelay(Duration.ofSeconds(1)) //


### PR DESCRIPTION
**What's in the PR**
- Add `sessionOwner` to `ViewportDefinition` to capture the subscribing user at subscription time
- Resolve session owner from viewport definition instead of `SecurityContextHolder` in render() to support renders triggered by non-web threads
- Add `/as/{sessionOwner}` routing segment to `DOCUMENT_VIEWPORT_TOPIC_TEMPLATE` and update `@SubscribeMapping` handler to validate session owner consistency
- Configure STOMP security rules for viewport topic to restrict subscriptions to self-owned documents
- Fix MDC context restoration in `sendUpdate` to properly save and restore `KEY_REPOSITORY_PATH` on all code paths
- Add `subscribeWithoutWaiting()` method to WebSocketStompTestClient for testing server-side subscription rejections
- Make `messageTimeout` configurable on WebSocketStompTestClient and lower default from 10 hours to 30 seconds
- Add comprehensive tests for viewport routing including scenarios with missing security context and concurrent writes by other users

**How to test manually**
*  Check if the annotation overview sidebar in particular still works as expected

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
