### PR TITLE
#6223 - Admin guide uses outdated property names

### DIFF
--- a/inception/inception-concept-linking/src/main/resources/META-INF/asciidoc/admin-guide/settings_concept-linking.adoc
+++ b/inception/inception-concept-linking/src/main/resources/META-INF/asciidoc/admin-guide/settings_concept-linking.adoc
@@ -55,27 +55,27 @@ examples of how the parameters can be configured below:
 | Default
 | Example
 
-| inception.entity-linking.cacheSize
+| knowledge-base.entity-linking.cache-size
 | Cache size
 | 1024
 | -
 
-| inception.entity-linking.candidateQueryLimit
+| knowledge-base.entity-linking.candidate-query-limit
 | Candidate Retrieval Limit
 | 2500
 | -
 
-| inception.entity-linking.mentionContextSize
+| knowledge-base.entity-linking.mention-context-size
 | Mention Context Size
 | 5
 | -
 
-| inception.entity-linking.candidateDisplayLimit
+| knowledge-base.entity-linking.candidate-display-limit
 | Candidate Display Limit
 | 100
 | -
 
-| inception.entity-linking.signatureQueryLimit
+| knowledge-base.entity-linking.signature-query-limit
 | Semantic Signature Query Limit
 | 2147483647
 | -

--- a/inception/inception-external-search-core/src/main/resources/META-INF/asciidoc/admin-guide/settings_external-search.adoc
+++ b/inception/inception-external-search-core/src/main/resources/META-INF/asciidoc/admin-guide/settings_external-search.adoc
@@ -28,7 +28,7 @@ This section describes the global settings related to the external document repo
 | Example
 
 
-| external-search.enable
+| external-search.enabled
 | Enable/disable document repository support
 | true
 | false

--- a/inception/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/admin-guide/settings_string_relation_recommender.adoc
+++ b/inception/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/admin-guide/settings_string_relation_recommender.adoc
@@ -27,7 +27,7 @@ You can enable the String recommender for relations in your {product-name} insta
 | Default
 | Example
 
-| recommender.string-matching.relation
+| recommender.string-matching.relation.enabled
 | enable/disable String relation recommender
 | false
 | true

--- a/inception/inception-scheduling/src/main/resources/META-INF/asciidoc/admin-guide/settings_scheduler.adoc
+++ b/inception/inception-scheduling/src/main/resources/META-INF/asciidoc/admin-guide/settings_scheduler.adoc
@@ -39,12 +39,12 @@ an example of how the parameter can be configured below:
 | Default
 | Example
 
-| inception.scheduler.numberOfThreads
+| inception.scheduling.number-of-threads
 | Number of threads that run tasks
 | 4
 | 8
 
-| inception.scheduler.queueSize
+| inception.scheduling.queue-size
 | Maximum number of tasks waiting for execution
 | 100
 | 200


### PR DESCRIPTION
**What's in the PR**
- Fix outdated property names in admin-guide documentation for external search, scheduler, concept linking, and string relation recommender

**How to test manually**
* Compare guide to code

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
