### PR TITLE
#6226 - Improve annotation detail sidebar layout

### DIFF
--- a/inception/inception-support-bootstrap/src/main/ts/bootstrap/_inception-feature-editors.scss
+++ b/inception/inception-support-bootstrap/src/main/ts/bootstrap/_inception-feature-editors.scss
@@ -38,6 +38,7 @@
         width: 100%;
         padding-right: calc(var(--bs-gutter-x) / 2);
         padding-left: calc(var(--bs-gutter-x) / 2);
+        white-space: normal;
     }
 
     .k-widget,

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
@@ -21,7 +21,7 @@
   <wicket:panel>
     <div id="annotationDetailEditorPanel" class="flex-content flex-v-container">
       <div wicket:id=deleteAnnotationDialog/>
-      <div id="annotationFeatureForm" class="annotatation-detail-panel flex-content flex-v-container flex-gutter">
+      <div id="annotationFeatureForm" class="annotatation-detail-panel flex-content flex-v-container flex-gutter flex-only-internal-gutter">
         <div wicket:id="layerContainer" class="card"/>
         <div class="flex-content panel card">
           <div wicket:id="header" class="card-header">


### PR DESCRIPTION
**What's in the PR**
- Apply flex-gutter whitespace normalization in feature editors to prevent nowrap from collapsing labels
- Add flex-only-internal-gutter class to annotation detail panel for improved spacing consistency

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
