### PR TITLE
#6231 - Annotations on TEI list items do not render until the document is scrolled

### DIFF
--- a/inception/inception-io-tei/src/main/ts/src/TeiXmlDocument.scss
+++ b/inception/inception-io-tei/src/main/ts/src/TeiXmlDocument.scss
@@ -61,6 +61,45 @@ TEI {
         display: block;
     }
 
+    list {
+        display: block;
+        margin-left: 1em;
+        list-style-type: none;
+    }
+
+    list > head {
+        font-size: 1em;
+    }
+
+    list > item {
+        display: list-item;
+        list-style-type: disc;
+        margin-left: 1em;
+    }
+
+    list > label,
+    list > headLabel,
+    list > headItem {
+        display: block;
+        font-weight: bold;
+    }
+
+    desc {
+        display: block;
+    }
+
+    salute,
+    signed,
+    dateline,
+    trailer,
+    docTitle,
+    docAuthor,
+    docDate,
+    docEdition,
+    imprimatur {
+        display: block;
+    }
+
     sp {
         margin-top: 1em;
         margin-left: 1em;


### PR DESCRIPTION
**What's in the PR**
- Add display rules for TEI list elements and text-bearing block elements (list, list > label, list > headLabel, list > headItem, desc, salute, signed, dateline, trailer, docTitle, docAuthor, docDate, docEdition, imprimatur) to prevent annotations from disappearing from view during scroll

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
