### PR TITLE
#6232 - Annotations disappear after scrolling quickly back up in the HTML editors

### DIFF
--- a/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.test.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.test.ts
@@ -94,6 +94,44 @@ describe('ViewportTracker (pause/resume)', () => {
         tracker.disconnect();
     });
 
+    it('does not narrow the range when elements are removed during the debounce window', () => {
+        const container = document.createElement('div');
+        const near = document.createElement('div');
+        near.style.display = 'block';
+        near.textContent = 'near';
+        const far = document.createElement('div');
+        far.style.display = 'block';
+        far.textContent = 'far away content';
+        container.appendChild(near);
+        container.appendChild(far);
+        document.body.appendChild(container);
+
+        const cb = vi.fn();
+        const tracker = new ViewportTracker(container, cb);
+        const obs = MockIntersectionObserver.lastInstance;
+        expect(obs).toBeTruthy();
+
+        // Both elements become visible - this addition schedules the debounced callback.
+        obs!.simulate([
+            { isIntersecting: true, target: near },
+            { isIntersecting: true, target: far },
+        ]);
+
+        // Copy: the accessor returns the live array by reference.
+        const rangeAtScheduleTime: [number, number] = [...tracker.currentRange];
+
+        // The far element scrolls out again before the debounce elapses. Removals must not
+        // recompute the range.
+        obs!.simulate([{ isIntersecting: false, target: far }]);
+
+        vi.advanceTimersByTime(300);
+
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith(rangeAtScheduleTime);
+
+        tracker.disconnect();
+    });
+
     it('suppresses callbacks while paused and resumes after resume', () => {
         const container = document.createElement('div');
         const child = document.createElement('div');

--- a/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
@@ -376,7 +376,6 @@ export class ViewportTracker {
     private initiateAction(): void {
         clearTimeout(this.redrawTimeoutId);
         this.redrawTimeoutId = setTimeout(() => {
-            this._currentRange = this.calculateWindowRange();
             console.debug('Invoking ViewportTracker callback with range', this._currentRange);
             this.callback(this._currentRange);
         }, this.debounceDelay);


### PR DESCRIPTION
**What's in the PR**
- Fix ViewportTracker narrowing its viewport range on fast scrolls, which dropped annotations from text that was still on screen
- Add regression test covering element removals arriving during the debounce window

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
