### PR TITLE
#6235 - PlantUML fails during build

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -1123,6 +1123,11 @@
               <artifactId>asciidoctorj-diagram</artifactId>
               <version>${asciidoctor-diagram.version}</version>
             </dependency>
+            <dependency>
+              <groupId>org.asciidoctor</groupId>
+              <artifactId>asciidoctorj-diagram-plantuml</artifactId>
+              <version>${asciidoctor-diagram-plantuml.version}</version>
+            </dependency>
           </dependencies>
         </plugin>
         <plugin>

--- a/inception/inception-doc/pom.xml
+++ b/inception/inception-doc/pom.xml
@@ -71,6 +71,12 @@
       <version>${asciidoctor-diagram.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj-diagram-plantuml</artifactId>
+      <version>${asciidoctor-diagram-plantuml.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <!--
@@ -127,6 +133,7 @@
               -->
               <usedDependency>org.asciidoctor:asciidoctorj</usedDependency>
               <usedDependency>org.asciidoctor:asciidoctorj-diagram</usedDependency>
+              <usedDependency>org.asciidoctor:asciidoctorj-diagram-plantuml</usedDependency>
               <!--
                 - Maven doesn't detect JS dependencies. We use this in docinfo.html
               -->

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <asciidoctor.plugin.version>3.2.0</asciidoctor.plugin.version>
     <asciidoctor.version>3.0.1</asciidoctor.version>
     <asciidoctor-diagram.version>3.2.1</asciidoctor-diagram.version>
+    <asciidoctor-diagram-plantuml.version>1.2024.5</asciidoctor-diagram-plantuml.version>
     <build-asciidoctorj-pdf-version>2.3.23</build-asciidoctorj-pdf-version>
 
     <ant-version>1.10.17</ant-version>


### PR DESCRIPTION
**What's in the PR**
- Add the `asciidoctorj-diagram-plantuml` dependency to the doc and webapp builds with a new `asciidoctor-diagram-plantuml.version` property

**How to test manually**
* Check that PlantUML diagram renders again

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
