### PR TITLE
#6216 - Audit log and logging user IP addresses

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionServletContextInitializer.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionServletContextInitializer.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.EventListener;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -36,15 +37,19 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.support.logging.LoggingFilter;
+import de.tudarmstadt.ukp.inception.support.logging.LoggingProperties;
+import de.tudarmstadt.ukp.inception.support.logging.LoggingPropertiesImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @Configuration
+@EnableConfigurationProperties(LoggingPropertiesImpl.class)
 public class InceptionServletContextInitializer
 {
     private @Autowired RepositoryProperties repoProperties;
+    private @Autowired LoggingProperties loggingProperties;
 
     @Bean
     public ServletListenerRegistrationBean<EventListener> springSessionLookup()
@@ -72,8 +77,8 @@ public class InceptionServletContextInitializer
     public FilterRegistrationBean<LoggingFilter> loggingFilter()
     {
         // Make username / repository accessible to logging framework
-        var registration = new FilterRegistrationBean<>(
-                new LoggingFilter(repoProperties.getPath().getAbsolutePath().toString()));
+        var registration = new FilterRegistrationBean<>(new LoggingFilter(
+                repoProperties.getPath().getAbsolutePath().toString(), loggingProperties));
         registration.setName("logging");
         registration.setDispatcherTypes(REQUEST, FORWARD, ASYNC);
         registration.setUrlPatterns(asList("/*"));

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/logging.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/logging.adoc
@@ -42,6 +42,44 @@ A custom logging configuration can be specified when starting up {product-name} 
 `-Dlogging.config=/path/to/your/log4.xml`. This should be a standard Log4J2 configuration file.
 A good starting point is the default configuration used by {product-name} which can be found in link:https://github.com/inception-project/inception/blob/main/inception/inception-app-webapp/src/main/resources/log4j2-spring.xml[our code repository].
 
+== Logging the remote address
+
+By default, {product-name} does not record the network address of the client from which a request
+originated. If your installation is subject to regulations requiring an audit trail that includes
+the client address, you can enable capturing it by adding the following property to the
+`settings.properties` file:
+
+[source,text]
+----
+logging.request.remote-address=true
+----
+
+When enabled, the remote address is made available to the logging framework as the
+`remoteAddress` context variable, which you can then include in the pattern of a
+custom logging configuration (cf. <<Custom logging>>):
+
+[source,text]
+----
+<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %level{length=5} [%encode{$${ctx:username:-SYSTEM}}{CRLF}] [%encode{$${ctx:remoteAddress:-}}{CRLF}] %logger{1} - %encode{%msg}{CRLF}%n" />
+----
+
+CAUTION: In many jurisdictions - e.g. under the GDPR in the European Union - the network address
+         of a client counts as personal data. Before enabling this setting, make sure that
+         recording it is covered by the privacy policy of your installation and that your log
+         retention policy accounts for it.
+
+There are two important limitations to be aware of:
+
+* **Only requests are covered.** The remote address is only available while {product-name} is
+  processing a request from the client. Work that happens on a background thread - most notably
+  project export, but also e.g. recommender training - is not associated with a client address and
+  the `remoteAddress` variable will be empty for any message logged from such a thread.
+* **Reverse proxies must be set up correctly.** If {product-name} runs behind a reverse proxy, the
+  address of the actual client is only recorded if the proxy has been set up as described in
+  <<sect_reverse_proxy>>. Otherwise, the address that ends up in the log is that of the proxy
+  rather than that of the client. You can inspect the effective settings on the *Network* page in
+  the administration dashboard.
+
 == Logging in JSON format
 
 If you would like to integrate the logging output of {product-name} with something like LogStash and

--- a/inception/inception-support/pom.xml
+++ b/inception/inception-support/pom.xml
@@ -101,6 +101,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-jdbc</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/logging/LoggingFilter.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/logging/LoggingFilter.java
@@ -28,17 +28,25 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class LoggingFilter
     implements Filter
 {
     public static final String PARAM_REPOSITORY_PATH = "repoPath";
 
-    private String repoPath;
+    private final String repoPath;
+    private final LoggingProperties properties;
 
     public LoggingFilter(String aRepoPath)
     {
+        this(aRepoPath, null);
+    }
+
+    public LoggingFilter(String aRepoPath, LoggingProperties aProperties)
+    {
         repoPath = aRepoPath;
+        properties = aProperties;
     }
 
     @Override
@@ -54,6 +62,13 @@ public class LoggingFilter
             setRepositoryPath(repoPath);
         }
 
+        var remoteAddressCaptured = false;
+        if (properties != null && properties.isRemoteAddress()
+                && req instanceof HttpServletRequest httpRequest) {
+            setRemoteAddress(httpRequest.getRemoteAddr());
+            remoteAddressCaptured = true;
+        }
+
         try {
             chain.doFilter(req, resp);
         }
@@ -64,6 +79,10 @@ public class LoggingFilter
 
             if (repoPath != null) {
                 clearRepositoryPath();
+            }
+
+            if (remoteAddressCaptured) {
+                clearRemoteAddress();
             }
         }
     }
@@ -94,5 +113,15 @@ public class LoggingFilter
     public static void clearRepositoryPath()
     {
         MDC.remove(Logging.KEY_REPOSITORY_PATH);
+    }
+
+    public static void setRemoteAddress(String aRemoteAddress)
+    {
+        MDC.put(Logging.KEY_REMOTE_ADDRESS, aRemoteAddress);
+    }
+
+    public static void clearRemoteAddress()
+    {
+        MDC.remove(Logging.KEY_REMOTE_ADDRESS);
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/logging/LoggingProperties.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/logging/LoggingProperties.java
@@ -17,15 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.support.logging;
 
-public final class Logging
+public interface LoggingProperties
 {
-    public static final String KEY_PROJECT_ID = "projectId";
-    public static final String KEY_USERNAME = "username";
-    public static final String KEY_REPOSITORY_PATH = "repositoryPath";
-    public static final String KEY_REMOTE_ADDRESS = "remoteAddress";
-
-    private Logging()
-    {
-        // No instances
-    }
+    boolean isRemoteAddress();
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/logging/LoggingPropertiesImpl.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/logging/LoggingPropertiesImpl.java
@@ -17,15 +17,28 @@
  */
 package de.tudarmstadt.ukp.inception.support.logging;
 
-public final class Logging
-{
-    public static final String KEY_PROJECT_ID = "projectId";
-    public static final String KEY_USERNAME = "username";
-    public static final String KEY_REPOSITORY_PATH = "repositoryPath";
-    public static final String KEY_REMOTE_ADDRESS = "remoteAddress";
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-    private Logging()
+@ConfigurationProperties("logging.request")
+public class LoggingPropertiesImpl
+    implements LoggingProperties
+{
+    /**
+     * Make the network address of the client from which a request originated available to the
+     * logging framework as the {@code remoteAddress} context variable. Note that in many
+     * jurisdictions - e.g. under the GDPR in the European Union - the network address of a client
+     * counts as personal data.
+     */
+    private boolean remoteAddress;
+
+    @Override
+    public boolean isRemoteAddress()
     {
-        // No instances
+        return remoteAddress;
+    }
+
+    public void setRemoteAddress(boolean aRemoteAddress)
+    {
+        remoteAddress = aRemoteAddress;
     }
 }

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/logging/LoggingFilterRemoteAddressTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/logging/LoggingFilterRemoteAddressTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * End-to-end check that the {@code remoteAddress} context variable documented in the admin guide
+ * really shows up in the formatted log output when {@code logging.request.remote-address} is
+ * enabled -- and that it does not when the setting is left at its default.
+ */
+class LoggingFilterRemoteAddressTest
+{
+    // The pattern the admin guide tells administrators to use. In an XML configuration file the
+    // lookups are written "$${ctx:...}" so that log4j re-evaluates them for every event instead of
+    // once at configuration time; a PatternLayout built in Java takes the pattern verbatim, so a
+    // single "$" is the equivalent here.
+    private static final String PATTERN = "[%encode{${ctx:username:-SYSTEM}}{CRLF}] "
+            + "[%encode{${ctx:remoteAddress:-}}{CRLF}] %encode{%msg}{CRLF}%n";
+
+    private static final String REMOTE_ADDRESS = "203.0.113.42";
+
+    private CapturingAppender appender;
+    private LoggerContext loggerContext;
+    private Level originalLevel;
+
+    @BeforeEach
+    void setup()
+    {
+        loggerContext = (LoggerContext) LogManager.getContext(false);
+        appender = new CapturingAppender(PatternLayout.newBuilder().withPattern(PATTERN)
+                .withConfiguration(loggerContext.getConfiguration()).build());
+        appender.start();
+        // The shared log4j2-test.xml pins the root logger to WARN, which would swallow the INFO
+        // messages this test logs, so raise the level for the duration of the test.
+        originalLevel = loggerContext.getConfiguration().getRootLogger().getLevel();
+        loggerContext.getConfiguration().getRootLogger().setLevel(Level.INFO);
+        loggerContext.getConfiguration().getRootLogger().addAppender(appender, null, null);
+        loggerContext.updateLoggers();
+    }
+
+    @AfterEach
+    void teardown()
+    {
+        loggerContext.getConfiguration().getRootLogger().removeAppender(appender.getName());
+        loggerContext.getConfiguration().getRootLogger().setLevel(originalLevel);
+        loggerContext.updateLoggers();
+        appender.stop();
+    }
+
+    @Test
+    void thatRemoteAddressAppearsInLogOutputWhenEnabled() throws Exception
+    {
+        runRequestThroughFilter(true);
+
+        assertThat(appender.messages) //
+                .as("the client address ends up in the formatted log line") //
+                .anyMatch(line -> line.contains("[" + REMOTE_ADDRESS + "]"));
+    }
+
+    @Test
+    void thatRemoteAddressIsAbsentFromLogOutputByDefault() throws Exception
+    {
+        runRequestThroughFilter(false);
+
+        assertThat(appender.messages) //
+                .as("nothing is logged in place of the client address") //
+                .isNotEmpty() //
+                .noneMatch(line -> line.contains(REMOTE_ADDRESS)) //
+                .allMatch(line -> line.contains("[] "));
+    }
+
+    @Test
+    void thatRemoteAddressDoesNotLeakAfterTheRequestCompletes() throws Exception
+    {
+        runRequestThroughFilter(true);
+
+        // Log from outside the filter -- e.g. a background thread reusing this thread later.
+        LoggerFactory.getLogger(getClass()).info("after the request");
+
+        assertThat(appender.messages) //
+                .as("the MDC is cleaned up so later messages carry no stale address") //
+                .filteredOn(line -> line.contains("after the request")) //
+                .isNotEmpty() //
+                .noneMatch(line -> line.contains(REMOTE_ADDRESS));
+    }
+
+    private void runRequestThroughFilter(boolean aEnabled) throws Exception
+    {
+        var request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn(REMOTE_ADDRESS);
+
+        LoggingProperties properties = () -> aEnabled;
+        var sut = new LoggingFilter(null, properties);
+
+        // The chain stands in for the application code that logs while handling the request.
+        sut.doFilter(request, null,
+                (req, resp) -> LoggerFactory.getLogger(getClass()).info("handling request"));
+    }
+
+    private static final class CapturingAppender
+        extends AbstractAppender
+    {
+        private final List<String> messages = new ArrayList<>();
+
+        CapturingAppender(PatternLayout aLayout)
+        {
+            super("capture", null, aLayout, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(org.apache.logging.log4j.core.LogEvent aEvent)
+        {
+            messages.add(new String(getLayout().toByteArray(aEvent),
+                    java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
@@ -860,6 +860,12 @@ public abstract class AnnotationPageBase2
         if (doc != null && !doc.equals(state.getDocument())) {
             LOG.trace("Changing document: {} (prev: {})", doc, state.getDocument());
             state.setDocument(doc, getListOfDocs());
+
+            if (state.getDocumentIndex() == -1) {
+                failWithDocumentNotFound("Document [" + doc.getName() + "] in project ["
+                        + project.getName() + "] is not available");
+                return;
+            }
         }
     }
 

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPageProperties.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPageProperties.java
@@ -22,4 +22,10 @@ import java.util.Set;
 public interface SettingsPageProperties
 {
     Set<String> getHiddenNamespaces();
+
+    /**
+     * @return namespaces exempted from {@link #getHiddenNamespaces()}. The most specific matching
+     *         namespace wins, so an entry here overrides a shorter entry in the hidden set.
+     */
+    Set<String> getVisibleNamespaces();
 }

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPagePropertiesImpl.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPagePropertiesImpl.java
@@ -33,7 +33,8 @@ public class SettingsPagePropertiesImpl
      * be a single segment (e.g. {@code "spring"}) to hide everything below it, or a dotted
      * multi-segment prefix (e.g. {@code "telemetry.matomo"}) to hide only that subtree. A property
      * is hidden when its name equals an entry, or starts with an entry followed by a dot. Matching
-     * is case-sensitive.
+     * is case-sensitive. Entries in {@code visibleNamespaces} take precedence over entries here if
+     * they are more specific.
      */
     // Default declared in META-INF/additional-spring-configuration-metadata.json
     // because the metadata processor cannot evaluate the LinkedHashSet/List.of expression.
@@ -57,5 +58,19 @@ public class SettingsPagePropertiesImpl
     public void setHiddenNamespaces(Set<String> aHiddenNamespaces)
     {
         hiddenNamespaces = aHiddenNamespaces != null ? aHiddenNamespaces : new LinkedHashSet<>();
+    }
+
+    private Set<String> visibleNamespaces = new LinkedHashSet<>(List.of( //
+            "logging.request"));
+
+    @Override
+    public Set<String> getVisibleNamespaces()
+    {
+        return visibleNamespaces;
+    }
+
+    public void setVisibleNamespaces(Set<String> aVisibleNamespaces)
+    {
+        visibleNamespaces = aVisibleNamespaces != null ? aVisibleNamespaces : new LinkedHashSet<>();
     }
 }

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceImpl.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceImpl.java
@@ -95,6 +95,7 @@ public class SpringConfigurationMetadataServiceImpl
     {
         var metadata = getMetadata();
         var hidden = settingsProperties.getHiddenNamespaces();
+        var visible = settingsProperties.getVisibleNamespaces();
         // Snapshot every PropertySource's property names once -- without this we'd rescan
         // every enumerable source for every metadata property, giving O(properties x sources
         // x keys) behavior on a page with thousands of keys across dozens of sources.
@@ -102,7 +103,7 @@ public class SpringConfigurationMetadataServiceImpl
 
         var views = new ArrayList<ConfigurationProperty>(metadata.size());
         for (var property : metadata) {
-            if (isHidden(property.getName(), hidden)) {
+            if (isHidden(property.getName(), hidden, visible)) {
                 continue;
             }
             views.add(toView(property, sources));
@@ -111,17 +112,33 @@ public class SpringConfigurationMetadataServiceImpl
         return views;
     }
 
-    private static boolean isHidden(String aName, Set<String> aHidden)
+    private static boolean isHidden(String aName, Set<String> aHidden, Set<String> aVisible)
     {
         if (aName == null || aHidden == null || aHidden.isEmpty()) {
             return false;
         }
-        for (var hidden : aHidden) {
-            if (aName.equals(hidden) || aName.startsWith(hidden + ".")) {
-                return true;
+
+        var hiddenMatch = longestMatch(aName, aHidden);
+        if (hiddenMatch < 0) {
+            return false;
+        }
+
+        return hiddenMatch >= longestMatch(aName, aVisible);
+    }
+
+    private static int longestMatch(String aName, Set<String> aNamespaces)
+    {
+        if (aNamespaces == null) {
+            return -1;
+        }
+
+        var result = -1;
+        for (var namespace : aNamespaces) {
+            if (aName.equals(namespace) || aName.startsWith(namespace + ".")) {
+                result = Math.max(result, namespace.length());
             }
         }
-        return false;
+        return result;
     }
 
     private ConfigurationProperty toView(ConfigurationMetadataProperty aProperty,

--- a/inception/inception-ui-dashboard/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-ui-dashboard/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -13,6 +13,12 @@
         "logging",
         "telemetry.matomo"
       ]
+    },
+    {
+      "name": "dashboard.admin-settings.visible-namespaces",
+      "defaultValue": [
+        "logging.request"
+      ]
     }
   ]
 }

--- a/inception/inception-ui-dashboard/src/test/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceIntegrationTest.java
+++ b/inception/inception-ui-dashboard/src/test/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceIntegrationTest.java
@@ -179,7 +179,7 @@ public class SpringConfigurationMetadataServiceIntegrationTest
     private SpringConfigurationMetadataServiceImpl newService()
     {
         return new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
-                () -> emptySet(), beanFactory);
+                namespaces(emptySet(), emptySet()), beanFactory);
     }
 
     private static ConfigurationProperty findProperty(List<ConfigurationProperty> aProperties,
@@ -248,7 +248,7 @@ public class SpringConfigurationMetadataServiceIntegrationTest
     void multiSegmentHiddenPrefixHidesOnlyMatchingSubtree()
     {
         var sut = new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
-                () -> Set.of("test-hidden.matomo"), beanFactory);
+                namespaces(Set.of("test-hidden.matomo"), emptySet()), beanFactory);
 
         var names = sut.listProperties().stream() //
                 .map(ConfigurationProperty::getName) //
@@ -261,11 +261,83 @@ public class SpringConfigurationMetadataServiceIntegrationTest
                 .contains("test-hidden.kept.flag");
     }
 
+    private static SettingsPageProperties namespaces(Set<String> aHidden, Set<String> aVisible)
+    {
+        var properties = new SettingsPagePropertiesImpl();
+        properties.setHiddenNamespaces(aHidden);
+        properties.setVisibleNamespaces(aVisible);
+        return properties;
+    }
+
+    /**
+     * A more specific visible namespace un-hides a subtree of an otherwise hidden namespace. This
+     * is what allows {@code logging.request} to show up on the settings page even though the
+     * framework-provided {@code logging} namespace as a whole is hidden.
+     */
+    @Test
+    void moreSpecificVisiblePrefixOverridesHiddenPrefix()
+    {
+        var sut = new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
+                namespaces(Set.of("test-hidden"), Set.of("test-hidden.kept")), beanFactory);
+
+        var names = sut.listProperties().stream() //
+                .map(ConfigurationProperty::getName) //
+                .filter(n -> n.startsWith("test-hidden.")) //
+                .toList();
+
+        assertThat(names) //
+                .as("the more specific visible prefix wins over the hidden one") //
+                .contains("test-hidden.kept.flag") //
+                .doesNotContain("test-hidden.matomo.flag");
+    }
+
+    /**
+     * A visible namespace that is less specific than the hidden one does not un-hide anything.
+     */
+    @Test
+    void lessSpecificVisiblePrefixDoesNotOverrideHiddenPrefix()
+    {
+        var sut = new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
+                namespaces(Set.of("test-hidden.matomo"), Set.of("test-hidden")), beanFactory);
+
+        var names = sut.listProperties().stream() //
+                .map(ConfigurationProperty::getName) //
+                .filter(n -> n.startsWith("test-hidden.")) //
+                .toList();
+
+        assertThat(names) //
+                .as("a less specific visible prefix does not win") //
+                .doesNotContain("test-hidden.matomo.flag") //
+                .contains("test-hidden.kept.flag");
+    }
+
+    /**
+     * The very same namespace declared as both hidden and visible stays hidden -- only a strictly
+     * more specific visible namespace un-hides a subtree.
+     */
+    @Test
+    void equallySpecificVisiblePrefixDoesNotOverrideHiddenPrefix()
+    {
+        var sut = new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
+                namespaces(Set.of("test-hidden.matomo"), Set.of("test-hidden.matomo")),
+                beanFactory);
+
+        var names = sut.listProperties().stream() //
+                .map(ConfigurationProperty::getName) //
+                .filter(n -> n.startsWith("test-hidden.")) //
+                .toList();
+
+        assertThat(names) //
+                .as("an equally specific visible prefix does not win") //
+                .doesNotContain("test-hidden.matomo.flag") //
+                .contains("test-hidden.kept.flag");
+    }
+
     @Test
     void topLevelHiddenPrefixHidesEntireSubtree()
     {
         var sut = new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
-                () -> Set.of("test-hidden"), beanFactory);
+                namespaces(Set.of("test-hidden"), emptySet()), beanFactory);
 
         var names = sut.listProperties().stream() //
                 .map(ConfigurationProperty::getName) //


### PR DESCRIPTION
**What's in the PR**
- Add `logging.request.remote-address` opt-in property to capture client network address in request logs
- Implement visible namespace mechanism in admin settings to un-hide properties from hidden namespaces when more specific
- Fix tie-break logic in namespace precedence to ensure equal-length hidden and visible entries favor hiding
- Expand test coverage for namespace precedence with equal-length and less-specific cases

**How to test manually**
* Follow configuration instructions and try it

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
